### PR TITLE
Construct GridEpiEnv and EpiSystem directly from population array

### DIFF
--- a/examples/Epidemiology/SEI2HRD_example.jl
+++ b/examples/Epidemiology/SEI2HRD_example.jl
@@ -40,13 +40,10 @@ param = transition(param)
 
 # Read in population sizes for Scotland
 scotpop = Array{Float64, 2}(readfile("test/examples/ScotlandDensity2011.tif", 0.0, 7e5, 5e5, 1.25e6))
-active = Array{Bool, 2}(.!isnan.(scotpop))
-scotpop = round.(scotpop)
 
 # Set up simple gridded environment
-grid = (700, 750)
 area = 525_000.0km^2
-epienv = simplehabitatAE(298.0K, grid, area, active, NoControl())
+epienv = simplehabitatAE(298.0K, area, NoControl(), scotpop)
 
 # Set population to initially have no individuals
 abun = fill(0, 8)
@@ -63,8 +60,6 @@ rel = Gauss{eltype(epienv.habitat)}()
 
 # Create epi system with all information
 epi = EpiSystem(epilist, epienv, rel)
-scotpop[isnan.(scotpop)] .= 0
-epi.abundances.grid[2, :, :] .+= scotpop
 
 # Add in initial infections randomly (samples weighted by population size)
 samp = sample(1:525_000, weights(1.0 .* epi.abundances.matrix[2, :]), 100)

--- a/examples/Epidemiology/Scotland_SIR_example.jl
+++ b/examples/Epidemiology/Scotland_SIR_example.jl
@@ -19,13 +19,10 @@ param = transition(param)
 
 # Read in population sizes for Scotland
 scotpop = Array{Float64, 2}(readfile("test/examples/ScotlandDensity2011.tif", 0.0, 7e5, 5e5, 1.25e6))
-active = Array{Bool, 2}(.!isnan.(scotpop))
-scotpop = round.(scotpop)
 
-# Set up simple gridded environment
-grid = (700, 750)
+# Set up simple gridded environment with initial population scotpop
 area = 525_000.0km^2
-epienv = simplehabitatAE(298.0K, grid, area, active, NoControl())
+epienv = simplehabitatAE(298.0K, area, NoControl(), scotpop)
 
 # Set population to initially have no individuals
 abun = fill(0, 5)
@@ -41,11 +38,8 @@ epilist = SIR(traits, abun, movement, param)
 rel = Gauss{eltype(epienv.habitat)}()
 
 # Create epi system with all information
+# This will fill in initial susceptible population (scotpop) from epienv
 epi = EpiSystem(epilist, epienv, rel)
-
-# Add in Scotland pop sizes
-scotpop[isnan.(scotpop)] .= 0
-epi.abundances.grid[2, :, :] .+= scotpop
 
 # Add in initial infections randomly (samples weighted by population size)
 samp = sample(1:525_000, weights(1.0 .* epi.abundances.matrix[2, :]), 100)
@@ -66,7 +60,7 @@ if do_plot
     # Plot heatmap of spatial disease progression
     abuns = Float64.(abuns)
     infecteds = abuns[3, :, :]
-    infecteds[.!active[1:end], :] .= NaN
+    infecteds[.!epi.epienv.active[1:end], :] .= NaN
     display(heatmap(reshape(infecteds[:, 1], 700, 750)', layout = (@layout [a b; c d]), subplot = 1, title = "Day 1", clim = (0, 2600), background_color = :lightblue, background_color_outside = :white, grid = false, aspect_ratio = 1, size = (1500, 1000), color = :fire_r))
     display(heatmap!(reshape(infecteds[:, 7], 700, 750)', subplot = 2, title = "Day 7", clim = (0, 2600), background_color = :lightblue, background_color_outside = :white, grid = false, aspect_ratio = 1, color = :fire_r))
     display(heatmap!(reshape(infecteds[:, 14], 700, 750)', subplot = 3, title = "Day 14", clim = (0, 2600), background_color = :lightblue, background_color_outside = :white, grid = false, aspect_ratio = 1, color = :fire_r))
@@ -80,7 +74,7 @@ if do_plot
     # Create animation of both
     abuns = Float64.(abuns)
     infecteds = abuns[3, :, :]
-    infecteds[.!active[1:end], :] .= NaN
+    infecteds[.!epi.epienv.active[1:end], :] .= NaN
     anim = @animate for i ∈ 1:365
         heatmap(reshape(infecteds[:, i], 700, 750)', layout = (@layout [a; b]), subplot = 1, title = "Day $i", clim = (0, 2500), grid = false, aspect_ratio = 1, size = (1200, 1500), color = :magma_r)
         plot!(mapslices(sum, abuns[2, :, 1:i], dims = 1)[1, :], color = :Blue, label = "Susceptible", subplot = 2, xlim = (0, 365), ylim = (0, 5.5e6), legend = :bottom, bottom_margin = 20* Plots.mm)

--- a/src/Epidemiology/EpiEnv.jl
+++ b/src/Epidemiology/EpiEnv.jl
@@ -78,7 +78,30 @@ function simplehabitatAE(
     area::Unitful.Area{Float64},
     control::C
 ) where C <: AbstractControl
-
     active = fill(true, dimension)
-    simplehabitatAE(val, dimension, area, active, control)
+    return simplehabitatAE(val, dimension, area, active, control)
+end
+
+"""
+    simplehabitatAE(
+        val::Union{Float64, Unitful.Quantity{Float64}},
+        population::Matrix{<:Real},
+        area::Unitful.Area{Float64},
+        control::C
+    )
+
+Create a simple `ContinuousHab` type epi environment from a specified `population` matrix.
+The dimensions of the habitat are derived from `population`. Values in `population` which
+are `NaN` are used to mask off inactive areas.
+"""
+function simplehabitatAE(
+    val::Union{Float64, Unitful.Quantity{Float64}},
+    population::Matrix{<:Real},
+    area::Unitful.Area{Float64},
+    control::C
+) where C <: AbstractControl
+    !all(isnan.(population)) || throw(ArgumentError("Specified population is all NaN"))
+    dimension = size(population)
+    active = Matrix{Bool}(.!isnan.(population))
+    return simplehabitatAE(val, dimension, area, active, control)
 end

--- a/src/Epidemiology/EpiEnv.jl
+++ b/src/Epidemiology/EpiEnv.jl
@@ -50,21 +50,29 @@ end
 Function to create a simple `ContinuousHab` type epi
 environment. It creates a `ContinuousHab` filled with a given value, `val`, dimensions (`dimension`) and a specified area (`area`). The rate of environmental change is specified using the parameter `rate`. If a Bool matrix of active grid squares is included, `active`, this is used, else one is created with all grid cells active.
 """
-function simplehabitatAE(val::Union{Float64, Unitful.Quantity{Float64}},
- dimension::Tuple{Int64, Int64}, area::Unitful.Area{Float64},
- active::Array{Bool, 2}, control::C) where C <: AbstractControl
- if typeof(val) <: Unitful.Temperature
-     val = uconvert(K, val)
- end
- area = uconvert(km^2, area)
- gridsquaresize = sqrt(area / (dimension[1] * dimension[2]))
- hab = simplehabitat(val, gridsquaresize, dimension)
- return GridEpiEnv{typeof(hab), typeof(control)}(hab, active, control)
+function simplehabitatAE(
+    val::Union{Float64, Unitful.Quantity{Float64}},
+    dimension::Tuple{Int64, Int64},
+    area::Unitful.Area{Float64},
+    active::Array{Bool, 2},
+    control::C
+) where C <: AbstractControl
+    if typeof(val) <: Unitful.Temperature
+        val = uconvert(K, val)
+    end
+    area = uconvert(km^2, area)
+    gridsquaresize = sqrt(area / (dimension[1] * dimension[2]))
+    hab = simplehabitat(val, gridsquaresize, dimension)
+    return GridEpiEnv{typeof(hab), typeof(control)}(hab, active, control)
 end
 
-function simplehabitatAE(val::Union{Float64, Unitful.Quantity{Float64}},
- dimension::Tuple{Int64, Int64}, area::Unitful.Area{Float64}, control::C) where C <: AbstractControl
+function simplehabitatAE(
+    val::Union{Float64, Unitful.Quantity{Float64}},
+    dimension::Tuple{Int64, Int64},
+    area::Unitful.Area{Float64},
+    control::C
+) where C <: AbstractControl
 
- active = fill(true, dimension)
- simplehabitatAE(val, dimension, area, active, control)
+    active = fill(true, dimension)
+    simplehabitatAE(val, dimension, area, active, control)
 end

--- a/src/Epidemiology/EpiEnv.jl
+++ b/src/Epidemiology/EpiEnv.jl
@@ -113,6 +113,7 @@ function simplehabitatAE(
     end
     dimension = size(initial_population)
     active = Matrix{Bool}(.!inactive.(initial_population))
+    initial_population[inactive.(initial_population)] .= 0
     initial_population = Int.(round.(initial_population))
     return simplehabitatAE(val, dimension, area, active, control)
 end

--- a/src/Epidemiology/EpiEnv.jl
+++ b/src/Epidemiology/EpiEnv.jl
@@ -81,16 +81,6 @@ function simplehabitatAE(
     return GridEpiEnv{typeof(hab), typeof(control)}(hab, active, control, initial_population)
 end
 
-function simplehabitatAE(
-    val::Union{Float64, Unitful.Quantity{Float64}},
-    dimension::Tuple{Int64, Int64},
-    area::Unitful.Area{Float64},
-    control::C
-) where C <: AbstractControl
-    active = fill(true, dimension)
-    return simplehabitatAE(val, dimension, area, active, control)
-end
-
 """
     simplehabitatAE(
         val::Union{Float64, Unitful.Quantity{Float64}},
@@ -124,5 +114,5 @@ function simplehabitatAE(
     active = Matrix{Bool}(.!inactive.(initial_population))
     initial_population[inactive.(initial_population)] .= 0
     initial_population = Int.(round.(initial_population))
-    return simplehabitatAE(val, dimension, area, active, control, initial_population)
+    return simplehabitatAE(val, dimension, area, control, active, initial_population)
 end

--- a/src/Epidemiology/EpiEnv.jl
+++ b/src/Epidemiology/EpiEnv.jl
@@ -68,8 +68,8 @@ function simplehabitatAE(
     val::Union{Float64, Unitful.Quantity{Float64}},
     dimension::Tuple{Int64, Int64},
     area::Unitful.Area{Float64},
+    active::Array{Bool, 2},
     control::C,
-    active::Array{Bool, 2}=fill(true, dimension),
     initial_population::Matrix{<:Integer}=zeros(Int, dimension),
 ) where C <: AbstractControl
     if typeof(val) <: Unitful.Temperature
@@ -79,6 +79,16 @@ function simplehabitatAE(
     gridsquaresize = sqrt(area / (dimension[1] * dimension[2]))
     hab = simplehabitat(val, gridsquaresize, dimension)
     return GridEpiEnv{typeof(hab), typeof(control)}(hab, active, control, initial_population)
+end
+
+function simplehabitatAE(
+    val::Union{Float64, Unitful.Quantity{Float64}},
+    dimension::Tuple{Int64, Int64},
+    area::Unitful.Area{Float64},
+    control::C,
+) where C <: AbstractControl
+    active = fill(true, dimension)
+    return simplehabitatAE(val, dimension, area, active, control)
 end
 
 """

--- a/src/Epidemiology/EpiEnv.jl
+++ b/src/Epidemiology/EpiEnv.jl
@@ -18,19 +18,24 @@ abstract type AbstractEpiEnv{H <: AbstractHabitat, C <: AbstractControl} <:
 """
     GridEpiEnv{H, C} <: AbstractAbiotic{H, C}
 
-This epi environment type holds a habitat and control strategy, as well as a string of subcommunity names.
+This epi environment type holds a habitat and control strategy, as well as a string of
+subcommunity names.
 """
 mutable struct GridEpiEnv{H, C} <: AbstractEpiEnv{H, C}
-  habitat::H
-  active::Array{Bool, 2}
-  control::C
-  names::Vector{String}
-  function (::Type{GridEpiEnv{H, C}})(habitat::H, active::Array{Bool,2}, control::C, names::Vector{String} =
-       map(x -> "$x", 1:countsubcommunities(habitat))) where {H, C}
-    countsubcommunities(habitat) == length(names) ||
-      error("Number of subcommunities must match subcommunity names")
-    return new{H, C}(habitat, active, control, names)
-  end
+    habitat::H
+    active::Array{Bool, 2}
+    control::C
+    names::Vector{String}
+    function (::Type{GridEpiEnv{H, C}})(
+        habitat::H,
+        active::Array{Bool,2},
+        control::C,
+        names::Vector{String}=map(x -> "$x", 1:countsubcommunities(habitat))
+    ) where {H, C}
+        countsubcommunities(habitat) == length(names) ||
+            error("Number of subcommunities must match subcommunity names")
+        return new{H, C}(habitat, active, control, names)
+    end
 end
 
 import Diversity.API: _countsubcommunities

--- a/src/Epidemiology/EpiEnv.jl
+++ b/src/Epidemiology/EpiEnv.jl
@@ -43,12 +43,18 @@ function _getsubcommunitynames(epienv::GridEpiEnv)
 end
 
 """
-    simplehabitatAE(val::Union{Float64, Unitful.Quantity{Float64}},
-    dimension::Tuple{Int64, Int64}, area::Unitful.Area{Float64},
-    active::Array{Bool, 2}, control::C)
+    function simplehabitatAE(
+        val::Union{Float64, Unitful.Quantity{Float64}},
+        dimension::Tuple{Int64, Int64},
+        area::Unitful.Area{Float64},
+        active::Array{Bool, 2},
+        control::C
+    )
 
-Function to create a simple `ContinuousHab` type epi
-environment. It creates a `ContinuousHab` filled with a given value, `val`, dimensions (`dimension`) and a specified area (`area`). The rate of environmental change is specified using the parameter `rate`. If a Bool matrix of active grid squares is included, `active`, this is used, else one is created with all grid cells active.
+Function to create a simple `ContinuousHab` type epi environment. It creates a
+`ContinuousHab` filled with a given value `val`, of dimensions `dimension` and specified
+area `area`. If a Bool matrix `active` of active grid squares is included, this is used,
+else one is created with all grid cells active.
 """
 function simplehabitatAE(
     val::Union{Float64, Unitful.Quantity{Float64}},

--- a/src/Epidemiology/EpiEnv.jl
+++ b/src/Epidemiology/EpiEnv.jl
@@ -124,5 +124,5 @@ function simplehabitatAE(
     active = Matrix{Bool}(.!inactive.(initial_population))
     initial_population[inactive.(initial_population)] .= 0
     initial_population = Int.(round.(initial_population))
-    return simplehabitatAE(val, dimension, area, control, active, initial_population)
+    return simplehabitatAE(val, dimension, area, active, control, initial_population)
 end

--- a/src/Epidemiology/EpiSystem.jl
+++ b/src/Epidemiology/EpiSystem.jl
@@ -62,9 +62,16 @@ function EpiSystem(popfun::Function, epilist::EpiList, epienv::GridEpiEnv, rel::
   EpiSystem{typeof(epienv), typeof(epilist), typeof(rel)}(ml, epilist, epienv, missing, rel, lookup_tab, EpiCache(nm, vm, false))
 end
 
-function EpiSystem(epilist::EpiList, epienv::GridEpiEnv,
-   rel::AbstractTraitRelationship)
-   return EpiSystem(populate!, epilist, epienv, rel)
+function EpiSystem(epilist::EpiList, epienv::GridEpiEnv, rel::AbstractTraitRelationship)
+    epi = EpiSystem(populate!, epilist, epienv, rel)
+    # Add in the initial susceptible population
+    idx = findfirst(epilist.names .== "Susceptible")
+    if idx == nothing
+        msg = "epilist has no Susceptible category. epilist.names = $(epilist.names)"
+        throw(ArgumentError(msg))
+    end
+    epi.abundances.grid[idx, :, :] .+= epienv.initial_population
+    return epi
 end
 
 

--- a/test/TestCases.jl
+++ b/test/TestCases.jl
@@ -65,6 +65,34 @@ function TestEpiSystem()
 
     return epi
 end
+function TestEpiSystemFromPopulation(initial_pop::Matrix{<:Real})
+    birth = [0.0/day; fill(1e-5/day, 3); 0.0/day]
+    death = [0.0/day; fill(1e-5/day, 3); 0.0/day]
+    beta = 0.0005/day
+    sigma = 0.05/day
+    virus_growth = 0.0001/day
+    virus_decay = 0.07/day
+    param = SIRGrowth{typeof(unit(beta))}(birth, death, virus_growth, virus_decay, beta, sigma)
+    param = transition(param)
+
+    area = 10.0km^2
+    epienv = simplehabitatAE(298.0K, area, NoControl(), initial_pop)
+
+    # Zero susceptible so we can test the specified initial_pop
+    abun = [10, 0, 1, 0, 0]
+
+    dispersal_dists = [1e-2km; fill(2.0km, 3); 1e-2km]
+    kernel = GaussianKernel.(dispersal_dists, 1e-10)
+    movement = AlwaysMovement(kernel)
+
+    traits = GaussTrait(fill(298.0K, 5), fill(0.1K, 5))
+    epilist = SIR(traits, abun, movement, param)
+
+    rel = Gauss{eltype(epienv.habitat)}()
+    epi = EpiSystem(epilist, epienv, rel)
+
+    return epi
+end
 
 
 function TestCache()

--- a/test/test_EpiEnv.jl
+++ b/test/test_EpiEnv.jl
@@ -20,3 +20,23 @@ abenv = simplehabitatAE(fillval, grid, area, control)
 @test abenv.active == active
 @test all(abenv.active)
 @test abenv.habitat.size^2 * grid[1] * grid[2] == area
+
+@testset "Constructing from initial population" begin
+    fillval = 1.0
+    area = 25.0km^2
+    control = NoControl()
+    initial_pop = rand(10, 15) * 10
+    # Fill some NaNs, these should indicate inactive areas
+    missing_idx = CartesianIndex.([1, 4, 8], [5, 8, 2])
+    initial_pop[missing_idx] .= NaN
+
+    expected_active = Matrix{Bool}(.!isnan.(initial_pop))
+    expected_size = size(initial_pop)
+    expected_pop = round.(replace(initial_pop, NaN => 0))
+
+    epienv = simplehabitatAE(fillval, area, control, initial_pop)
+    @test all(epienv.habitat.matrix .== fillval)
+    @test size(epienv.habitat.matrix) == expected_size
+    @test epienv.active == expected_active
+    @test epienv.initial_population == expected_pop
+end

--- a/test/test_EpiSystem.jl
+++ b/test/test_EpiSystem.jl
@@ -24,6 +24,12 @@ epi = TestEpiSystem()
 @test_nowarn getdispersalvar(epi, 1)
 @test_nowarn getdispersalvar(epi, "Virus")
 
+@testset "EpiSystem from initial population" begin
+    initial_pop = rand(10, 10) * 10
+    epi = TestEpiSystemFromPopulation(initial_pop)
+    @test epi.epienv.initial_population == round.(initial_pop)
+    @test epi.abundances.grid[2, :, :] == round.(initial_pop)
+end
 
 @testset "Approximate equality" begin
     atol = 1
@@ -36,7 +42,6 @@ epi = TestEpiSystem()
     epi_2.abundances.matrix[2, 1] += 1000
     @test !isapprox(epi_2, epi; atol=atol)
 end
-
 
 @testset "save and load (with JLSO)" begin
     # Test saving Function


### PR DESCRIPTION
Closes https://github.com/ScottishCovidResponse/SCRCIssueTracking/issues/10

- This allows `simplehabitatAE` to take in a population array directly. This is used to infer the grid dimensions and active area (anything which isn't NaN/missing)
- Added extra field `initial_population` to `GridEpiEnv`, to store the specified population array
- The `EpiSystem` constructor then uses `GridEpiEnv.initial_population` to populate the susceptible category of its `EpiLandscape` (basically what was being done manually in the example files previously)
- Updated the examples and added tests
- I kept all the previous constructor functionality, so these changes *should* be non-breaking