### PR TITLE
Shrink grid to fit

### DIFF
--- a/examples/Epidemiology/SEI2HRD_example.jl
+++ b/examples/Epidemiology/SEI2HRD_example.jl
@@ -62,12 +62,13 @@ rel = Gauss{eltype(epienv.habitat)}()
 epi = EpiSystem(epilist, epienv, rel)
 
 # Add in initial infections randomly (samples weighted by population size)
-samp = sample(1:525_000, weights(1.0 .* epi.abundances.matrix[2, :]), 100)
+N_cells = size(epi.abundances.matrix, 2)
+samp = sample(1:N_cells, weights(1.0 .* epi.abundances.matrix[2, :]), 100)
 epi.abundances.matrix[1, samp] .= 100 # Virus pop
 epi.abundances.matrix[4:5, samp] .= 10 # Inf pop
 
 # Run simulation
-abuns = zeros(Int64, 8, 525_000, 366)
+abuns = zeros(Int64, 8, N_cells, 366)
 times = 1year; interval = 1day; timestep = 1day
 @time simulate_record!(abuns, epi, times, interval, timestep)
 

--- a/examples/Epidemiology/Scotland_SIR_example.jl
+++ b/examples/Epidemiology/Scotland_SIR_example.jl
@@ -43,12 +43,13 @@ rel = Gauss{eltype(epienv.habitat)}()
 epi = EpiSystem(epilist, epienv, rel)
 
 # Add in initial infections randomly (samples weighted by population size)
-samp = sample(1:525_000, weights(1.0 .* epi.abundances.matrix[2, :]), 100)
+N_cells = size(epi.abundances.matrix, 2)
+samp = sample(1:N_cells, weights(1.0 .* epi.abundances.matrix[2, :]), 100)
 epi.abundances.matrix[1, samp] .= 100 # Virus pop
 epi.abundances.matrix[3, samp] .= 10 # Infected pop
 
 # Run simulation
-abuns = zeros(Int64, 5, 525_000, 366)
+abuns = zeros(Int64, 5, N_cells, 366)
 times = 1year; interval = 1day; timestep = 1day
 @time simulate_record!(abuns, epi, times, interval, timestep)
 

--- a/examples/Epidemiology/Small_SIR.jl
+++ b/examples/Epidemiology/Small_SIR.jl
@@ -54,11 +54,12 @@ end
 # Again, but with larger grid
 birth = [0.0/day; fill(1e-5/day, 3); 0.0/day]
 death = [0.0/day; fill(1e-5/day, 3); 0.0/day]
-beta = 0.05/day
+beta_force = 0.05/day
+beta_env = 0.05/day
 sigma = 0.05/day
 virus_growth = 0.0001/day
 virus_decay = 0.07/day
-param = SIRGrowth{typeof(unit(beta))}(birth, death, virus_growth, virus_decay, beta, sigma)
+param = SIRGrowth{typeof(unit(beta_force))}(birth, death, virus_growth, virus_decay, beta_force, beta_env, sigma)
 param = transition(param)
 
 grid = (10, 10)

--- a/src/Epidemiology/EpiEnv.jl
+++ b/src/Epidemiology/EpiEnv.jl
@@ -96,6 +96,9 @@ Function to create a simple `ContinuousHab` type epi environment. It creates a
 `ContinuousHab` filled with a given value `val`, of dimensions `dimension` and specified
 area `area`. If a Bool matrix `active` of active grid squares is included, this is used,
 else one is created with all grid cells active.
+
+!!! note
+    The simulation grid will be shrunk so that it tightly wraps the active values
 """
 function simplehabitatAE(
     val::Union{Float64, Unitful.Quantity{Float64}},
@@ -110,6 +113,13 @@ function simplehabitatAE(
     end
     area = uconvert(km^2, area)
     gridsquaresize = sqrt(area / (dimension[1] * dimension[2]))
+
+    # Shrink to active region
+    # This doesn't change the gridsquaresize
+    initial_population = _shrink_to_active(initial_population, active)
+    active = _shrink_to_active(active, active)
+    dimension = size(active)
+
     hab = simplehabitat(val, gridsquaresize, dimension)
     return GridEpiEnv{typeof(hab), typeof(control)}(hab, active, control, initial_population)
 end
@@ -142,6 +152,10 @@ matrix.
     used to mask off inactive areas. `initial_population` will be rounded to integers.
 - `area`: The area of the habitat
 - `control`: The control to apply
+
+!!! note
+    The simulation grid will be shrunk so that it tightly wraps the active values in
+    `initial_population`.
 """
 function simplehabitatAE(
     val::Union{Float64, Unitful.Quantity{Float64}},

--- a/src/Epidemiology/EpiEnv.jl
+++ b/src/Epidemiology/EpiEnv.jl
@@ -62,6 +62,27 @@ function _getsubcommunitynames(epienv::GridEpiEnv)
 end
 
 """
+    _shrink_to_active(M::AbstractMatrix, active::AbstractMatrix{<:Bool})
+
+Shrink the matrix `M` to the minimum rectangular region which contains all active cells, as
+defined by `active`. Returns the shrunk matrix.
+"""
+function _shrink_to_active(M::AbstractMatrix, active::AbstractMatrix{<:Bool})
+    if size(M) != size(active)
+        throw(DimensionMismatch("size(M)=$(size(M)) != size(active)=$(size(active))"))
+    end
+    # Find indices of non-missing values
+    idx = Tuple.(findall(active))
+    # Separate into row and column indices
+    row_idx = first.(idx)
+    col_idx = last.(idx)
+    # Return the shrunk region
+    shrunk_rows = minimum(row_idx):maximum(row_idx)
+    shrunk_cols = minimum(col_idx):maximum(col_idx)
+    return M[shrunk_rows, shrunk_cols]
+end
+
+"""
     function simplehabitatAE(
         val::Union{Float64, Unitful.Quantity{Float64}},
         dimension::Tuple{Int64, Int64},

--- a/src/Epidemiology/EpiEnv.jl
+++ b/src/Epidemiology/EpiEnv.jl
@@ -36,6 +36,18 @@ mutable struct GridEpiEnv{H, C} <: AbstractEpiEnv{H, C}
     ) where {H, C}
         countsubcommunities(habitat) == length(names) ||
             error("Number of subcommunities must match subcommunity names")
+        if size(habitat.matrix) != size(active)
+            throw(DimensionMismatch(
+                "size(habitat.matrix)=$(size(habitat.matrix)) != " *
+                "size(active)=$(size(active))"
+            ))
+        end
+        if size(initial_population) != size(active)
+            throw(DimensionMismatch(
+                "size(initial_population)=$(size(initial_population)) != " *
+                "size(active)=$(size(active))"
+            ))
+        end
         return new{H, C}(habitat, active, control, initial_population, names)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,12 +1,16 @@
 # Identify files in test/ that are testing matching files in src/
 #  - src/Source.jl will be matched by test/test_Source.jl
 using Compat
+using Random
 using Test
 
 filebase = map(file -> replace(file, r"(.*).jl" => s"\1"),
                 filter(file -> occursin(r".*\.jl", file), readdir("../src")))
 testbase = map(file -> replace(file, r"test_(.*).jl" => s"\1"),
                 filter(str -> occursin(r"^test_.*\.jl$", str), readdir()))
+
+# Seed RNG to make tests reproducible
+Random.seed!(1234)
 
 @testset "Simulation.jl" begin
     @info "Running tests for files:"

--- a/test/test_EpiEnv.jl
+++ b/test/test_EpiEnv.jl
@@ -47,23 +47,23 @@ end
     fillval = 1.0
 
     active = fill(true, grid)
-    # Set inactive cells on the outer two layers
+    # Set inactive cells on the outer layers
+    # Make this asymmetric to be more general
     # These should be trimmed off
-    for row in (1, 2, 9, 10)
+    for row in (1, 2, 3, 10)
         active[row, :] .= false
     end
-    for col in (1, 2, 9, 10)
+    for col in (1, 2, 10)
         active[:, col] .= false
     end
     # Set some more inactive cells, these shouldn't result in any further trimming
-    active[3, 3] = false
-    active[4, 3] = false
+    active[4, 4] = false
+    active[5, 4] = false
     active[5, 5] = false
     active[8, 8] = false
-    # Should be trimmed from 10^2 to 8^2
-    expected_grid= (8, 8)
-    expected_active = active[3:8, 3:8]
-    expected_area = area * (8/10)^2
+    # Should be trimmed from 10x10 to 6x7
+    expected_grid= (6, 7)
+    expected_active = active[4:9, 3:9]
     # Shouldn't change
     expected_gridlength = 1km
     control = NoControl()

--- a/test/test_EpiEnv.jl
+++ b/test/test_EpiEnv.jl
@@ -70,7 +70,7 @@ end
     expected_matrix = fill(fillval, expected_grid)
 
     @testset "Construct directly" begin
-        epienv = simplehabitatAE(fillval, grid, area, control)
+        epienv = simplehabitatAE(fillval, grid, area, active, control)
 
         @test epienv.active == expected_active
         @test size(epienv.habitat.matrix) == expected_grid

--- a/test/test_EpiEnv.jl
+++ b/test/test_EpiEnv.jl
@@ -83,8 +83,8 @@ end
 
         @test epienv.active == expected_active
         @test size(epienv.habitat.matrix) == expected_grid
-        @test epienv.habitat.size ≈ expected_gridlength
-        @test epienv.habitat.matrix ≈ expected_matrix
+        @test epienv.habitat.size == expected_gridlength
+        @test epienv.habitat.matrix == expected_matrix
     end
 
     @testset "Construct from initial population" begin
@@ -98,8 +98,8 @@ end
 
         @test epienv.active == expected_active
         @test size(epienv.habitat.matrix) == expected_grid
-        @test epienv.habitat.size ≈ expected_gridlength
-        @test epienv.habitat.matrix ≈ expected_matrix
-        @test epienv.initial_pop ≈ expected_initial_pop
+        @test epienv.habitat.size == expected_gridlength
+        @test epienv.habitat.matrix == expected_matrix
+        @test epienv.initial_population == expected_initial_pop
     end
 end

--- a/test/test_EpiEnv.jl
+++ b/test/test_EpiEnv.jl
@@ -40,3 +40,57 @@ abenv = simplehabitatAE(fillval, grid, area, control)
     @test epienv.active == expected_active
     @test epienv.initial_population == expected_pop
 end
+
+@testset "Shrink grid" begin
+    grid = (10, 10)
+    area = 100.0km^2
+    fillval = 1.0
+
+    active = fill(true, grid)
+    # Set inactive cells on the outer two layers
+    # These should be trimmed off
+    for row in (1, 2, 9, 10)
+        active[row, :] .= false
+    end
+    for col in (1, 2, 9, 10)
+        active[:, col] .= false
+    end
+    # Set some more inactive cells, these shouldn't result in any further trimming
+    active[3, 3] = false
+    active[4, 3] = false
+    active[5, 5] = false
+    active[8, 8] = false
+    # Should be trimmed from 10^2 to 8^2
+    expected_grid= (8, 8)
+    expected_active = active[3:8, 3:8]
+    expected_area = area * (8/10)^2
+    # Shouldn't change
+    expected_gridlength = 1km
+    control = NoControl()
+    expected_matrix = fill(fillval, expected_grid)
+
+    @testset "Construct directly" begin
+        epienv = simplehabitatAE(fillval, grid, area, control)
+
+        @test epienv.active == expected_active
+        @test size(epienv.habitat.matrix) == expected_grid
+        @test epienv.habitat.size ≈ expected_gridlength
+        @test epienv.habitat.matrix ≈ expected_matrix
+    end
+
+    @testset "Construct from initial population" begin
+        # Set an initial population of zeros
+        # The zeros should not be masked out (but the NaNs should)
+        initial_pop = zeros(grid...)
+        initial_pop[.!active] .= NaN
+
+        epienv = simplehabitatAE(fillval, area, control, initial_pop)
+        expected_initial_pop = zeros(expected_grid)
+
+        @test epienv.active == expected_active
+        @test size(epienv.habitat.matrix) == expected_grid
+        @test epienv.habitat.size ≈ expected_gridlength
+        @test epienv.habitat.matrix ≈ expected_matrix
+        @test epienv.initial_pop ≈ expected_initial_pop
+    end
+end

--- a/test/test_EpiEnv.jl
+++ b/test/test_EpiEnv.jl
@@ -61,13 +61,22 @@ end
     active[5, 4] = false
     active[5, 5] = false
     active[8, 8] = false
-    # Should be trimmed from 10x10 to 6x7
-    expected_grid= (6, 7)
-    expected_active = active[4:9, 3:9]
+    # This should stop col 2 being trimmed
+    active[5, 2] = true
+    # Should be trimmed from 10x10 to 6x8
+    expected_grid= (6, 8)
+    expected_active = active[4:9, 2:9]
     # Shouldn't change
     expected_gridlength = 1km
     control = NoControl()
     expected_matrix = fill(fillval, expected_grid)
+
+    @testset "_shrink_to_active" begin
+        M = rand(grid...)
+        M_shrunk = Simulation._shrink_to_active(M, active)
+        @test size(M_shrunk) == expected_grid
+        @test M_shrunk == M[4:9, 2:9]
+    end
 
     @testset "Construct directly" begin
         epienv = simplehabitatAE(fillval, grid, area, active, control)


### PR DESCRIPTION
Addresses https://github.com/ScottishCovidResponse/SCRCIssueTracking/issues/3

- In `simplehabitatAE`, shrinks the grid so that it is tightly bound with respect to the active cells. This should remove a bunch of inactive cells from the edges, although there will still potentially be large inactive regions in the 'interior' 
- This is always done. We could make it optional, but I can't see any cases where we wouldn't want it?
- Fix up the examples (since above changes the grid size, can't hardcode it in the scripts)
- Seed the RNG in `runtests.jl`, this makes our tests reproducible (generally good practice, and should stop stochastic failures in CI)