### PR TITLE
Age structure

### DIFF
--- a/examples/Epidemiology/SEI2HRD_example.jl
+++ b/examples/Epidemiology/SEI2HRD_example.jl
@@ -11,10 +11,8 @@ do_plot = false
 birth_rates = 1e-5/day; death_rates = birth_rates
 birth = [0.0/day; fill(birth_rates, 6); 0.0/day]
 death = [0.0/day; fill(death_rates, 6); 0.0/day]
-virus_growth = fill(0.0/day, 8)
-virus_growth[4:5] .= 0.1/day
-virus_decay = fill(0.0/day, 8)
-virus_decay[4] = 1.0/day
+virus_growth_asymp = virus_growth_symp = 0.1/day
+virus_decay = 1.0/day
 beta_force = 10.0/day
 beta_env = 10.0/day
 
@@ -35,7 +33,7 @@ T_hosp = 5days
 # Time to recovery if symptomatic
 T_rec = 11days
 
-param = SEI2HRDGrowth(birth, death, virus_growth, virus_decay, beta_force, beta_env, p_s, p_h, cfr_home, cfr_hospital, T_lat, T_asym, T_sym, T_hosp, T_rec)
+param = SEI2HRDGrowth(birth, death, virus_growth_asymp, virus_growth_symp, virus_decay, beta_force, beta_env, p_s, p_h, cfr_home, cfr_hospital, T_lat, T_asym, T_sym, T_hosp, T_rec)
 param = transition(param)
 
 # Read in population sizes for Scotland
@@ -68,7 +66,7 @@ epi.abundances.matrix[4:5, samp] .= 10 # Inf pop
 
 # Run simulation
 abuns = zeros(Int64, 8, 525_000, 366)
-times = 1year; interval = 1day; timestep = 1day
+times = 2months; interval = 1day; timestep = 1day
 @time simulate_record!(abuns, epi, times, interval, timestep)
 
 if do_plot

--- a/src/Epidemiology/EpiGenerate.jl
+++ b/src/Epidemiology/EpiGenerate.jl
@@ -64,7 +64,7 @@ function virusupdate!(epi::EpiSystem, timestep::Unitful.Time)
             if epi.epienv.active[x, y]
                 traitmatch = traitfun(epi, i, 1)
                 # Calculate effective rates
-                birthrate = params.virus_growth[j] * timestep * epi.abundances.matrix[j, i]
+                birthrate = params.virus_growth[j] * timestep * epi.abundances.matrix[j + 1, i]
                 deathrate = params.virus_decay[j] * timestep * traitmatch^-1
 
                 # Convert death rate into 0 - 1 probability

--- a/src/Epidemiology/EpiList.jl
+++ b/src/Epidemiology/EpiList.jl
@@ -66,49 +66,57 @@ function _getdiversityname(el::EpiList)
 end
 
 function SIS(traits::TR, abun::Vector{Int64},
-    movement::MO, params::P) where {TR <: AbstractTraits,
+    movement::MO, params::P, age_categories::Int64 = 1) where {TR <: AbstractTraits,
         MO <: AbstractMovement, P <: AbstractParams}
 
-    names = ["Virus", "Susceptible", "Infected", "Dead"]
-    types = UniqueTypes(length(names))
-    length(abun) == length(names) || throw(DimensionMismatch("Abundance vector doesn't match number of disease classes"))
-  EpiList{typeof(traits), typeof(movement), typeof(types), typeof(params)}(names, traits, abun, types, movement, params)
+    names = ["Susceptible", "Infected", "Dead"]
+    new_names = [ifelse(i == 1, "$j", "$j$i") for i in 1:age_categories, j in names]
+    new_names =  ["Virus"; new_names[1:end]]
+    types = UniqueTypes(length(new_names))
+    length(abun) == length(new_names) || throw(DimensionMismatch("Abundance vector doesn't match number of disease classes"))
+  EpiList{typeof(traits), typeof(movement), typeof(types), typeof(params)}(new_names, traits, abun, types, movement, params)
 end
 
 function SIR(traits::TR, abun::Vector{Int64},
-    movement::MO, params::P) where {TR <: AbstractTraits,
+    movement::MO, params::P, age_categories::Int64 = 1) where {TR <: AbstractTraits,
         MO <: AbstractMovement, P <: AbstractParams}
 
-    names = ["Virus", "Susceptible", "Infected", "Recovered", "Dead"]
-    types = UniqueTypes(length(names))
-    length(abun) == length(names) || throw(DimensionMismatch("Abundance vector doesn't match number of disease classes"))
-  EpiList{typeof(traits), typeof(movement), typeof(types), typeof(params)}(names, traits, abun, types, movement, params)
+    names = ["Susceptible", "Infected", "Recovered", "Dead"]
+    new_names = [ifelse(i == 1, "$j", "$j$i") for i in 1:age_categories, j in names]
+    new_names =  ["Virus"; new_names[1:end]]
+    types = UniqueTypes(length(new_names))
+    length(abun) == length(new_names) || throw(DimensionMismatch("Abundance vector doesn't match number of disease classes"))
+  EpiList{typeof(traits), typeof(movement), typeof(types), typeof(params)}(new_names, traits, abun, types, movement, params)
 end
 
 function SEIR(traits::TR, abun::Vector{Int64},
-    movement::MO, params::P) where {TR <: AbstractTraits,
+    movement::MO, params::P, age_categories::Int64 = 1) where {TR <: AbstractTraits,
         MO <: AbstractMovement, P <: AbstractParams}
 
-    names = ["Virus", "Susceptible", "Exposed", "Infected", "Recovered", "Dead"]
-    types = UniqueTypes(length(names))
-    length(abun) == length(names) || throw(DimensionMismatch("Abundance vector doesn't match number of disease classes"))
-  EpiList{typeof(traits), typeof(movement), typeof(types), typeof(params)}(names, traits, abun, types, movement, params)
+    names = ["Susceptible", "Exposed", "Infected", "Recovered", "Dead"]
+    new_names = [ifelse(i == 1, "$j", "$j$i") for i in 1:age_categories, j in names]
+    new_names =  ["Virus"; new_names[1:end]]
+    types = UniqueTypes(length(new_names))
+    length(abun) == length(new_names) || throw(DimensionMismatch("Abundance vector doesn't match number of disease classes"))
+  EpiList{typeof(traits), typeof(movement), typeof(types), typeof(params)}(new_names, traits, abun, types, movement, params)
 end
 
 function SEIRS(traits::TR, abun::Vector{Int64},
-    movement::MO, params::P) where {TR <: AbstractTraits,
+    movement::MO, params::P, age_categories::Int64 = 1) where {TR <: AbstractTraits,
         MO <: AbstractMovement, P <: AbstractParams}
 
-    return SEIR(traits, abun, movement, params)
+    return SEIR(traits, abun, movement, params, age_categories)
 end
 
 function SEI2HRD(traits::TR, abun::Vector{Int64},
-    movement::MO, params::P) where {TR <: AbstractTraits,
+    movement::MO, params::P, age_categories::Int64 = 1) where {TR <: AbstractTraits,
         MO <: AbstractMovement, P <: AbstractParams}
 
-    names = ["Virus", "Susceptible", "Exposed", "AsymptomaticInfected", "SymptomaticInfected", "Hospitalised", "Recovered", "Dead"]
-    types = UniqueTypes(length(names))
-    length(abun) == length(names) || throw(DimensionMismatch("Abundance vector doesn't match number of disease classes"))
-    size(params.transition, 1) == length(names) || throw(DimensionMismatch("Transition matrix does not have the correct number of classes"))
-  EpiList{typeof(traits), typeof(movement), typeof(types), typeof(params)}(names, traits, abun, types, movement, params)
+    names = ["Susceptible", "Exposed", "AsymptomaticInfected", "SymptomaticInfected", "Hospitalised", "Recovered", "Dead"]
+    new_names = [ifelse(i == 1, "$j", "$j$i") for i in 1:age_categories, j in names]
+    new_names =  ["Virus"; new_names[1:end]]
+    types = UniqueTypes(length(new_names))
+    length(abun) == length(new_names) || throw(DimensionMismatch("Abundance vector doesn't match number of disease classes"))
+    size(params.transition, 1) == (length(new_names) - 1) || throw(DimensionMismatch("Transition matrix does not have the correct number of classes"))
+  EpiList{typeof(traits), typeof(movement), typeof(types), typeof(params)}(new_names, traits, abun, types, movement, params)
 end

--- a/src/Epidemiology/EpiParams.jl
+++ b/src/Epidemiology/EpiParams.jl
@@ -314,7 +314,7 @@ function create_transition_matrix(params::AbstractParams, paramDat::DataFrame, a
 
     # Set up transition matrix
     tm_size = nclasses * age_categories
-    tmat = zeros(typeof(paramDat[1, :param][1]), tm_size, tm_size)
+    tmat = zeros(typeof(params.beta_env[1]), tm_size, tm_size)
 
     # Ageing
     for i in 1:(nclasses-1)
@@ -478,7 +478,7 @@ function transition(params::SEI2HRDGrowth, age_categories = 1)
     death_hospitalised = params.death_hospital)
     from = [2, 3, 4, 3, 4, 5, 4, 5]
     to = [3, 4, 5, 6, 6, 6, 7, 7]
-    paramDat = DataFrame(from = from, to = to, param = ordered_transitions)
+    paramDat = DataFrame(from = from, to = to, param = collect(ordered_transitions))
 
     tmat = create_transition_matrix(params, paramDat, age_categories, nclasses)
 
@@ -489,8 +489,8 @@ function transition(params::SEI2HRDGrowth, age_categories = 1)
     vfmat = create_virus_matrix(params.beta_force, age_categories, nclasses)
 
     # Virus growth and decay
-    v_growth, v_decay = create_virus_vector(params.virus_growth, params.virus_decay, age_categories, nclasses, 3)
-    v_growth .+= create_virus_vector(params.virus_growth, params.virus_decay, age_categories, nclasses, 4)[1]
+    v_growth, v_decay = create_virus_vector(params.virus_growth_asymp, params.virus_decay, age_categories, nclasses, 3)
+    v_growth .+= create_virus_vector(params.virus_growth_symp, params.virus_decay, age_categories, nclasses, 4)[1]
 
   return EpiParams{typeof(unit(params.beta_force[1]))}(params.birth[1:end], v_growth, v_decay, tmat, vfmat, vmat)
 end

--- a/src/Epidemiology/EpiParams.jl
+++ b/src/Epidemiology/EpiParams.jl
@@ -1,4 +1,5 @@
 using Unitful
+using LinearAlgebra
 
 """
     SIRGrowth{U <: Unitful.Units} <: AbstractParams
@@ -6,17 +7,24 @@ using Unitful
 Parameter set that houses information on birth and death rates of different classes in an SIR model, as well as growth and decay of virus, and infection/recovery parameters.
 """
 mutable struct SIRGrowth{U <: Unitful.Units} <: AbstractParams
-      birth::Vector{TimeUnitType{U}}
-      death::Vector{TimeUnitType{U}}
-      virus_growth::TimeUnitType{U}
-      virus_decay::TimeUnitType{U}
-      beta_force::TimeUnitType{U}
-      beta_env::TimeUnitType{U}
-      sigma::TimeUnitType{U}
+      birth::Matrix{TimeUnitType{U}}
+      death::Matrix{TimeUnitType{U}}
+      virus_growth::Vector{TimeUnitType{U}}
+      virus_decay::Vector{TimeUnitType{U}}
+      beta_force::Vector{TimeUnitType{U}}
+      beta_env::Vector{TimeUnitType{U}}
+      sigma::Vector{TimeUnitType{U}}
+    function SIRGrowth{U}(birth::Matrix{TimeUnitType{U}},
+        death::Matrix{TimeUnitType{U}}, virus_growth::Vector{TimeUnitType{U}}, virus_decay::Vector{TimeUnitType{U}}, beta_force::Vector{TimeUnitType{U}}, beta_env::Vector{TimeUnitType{U}}, sigma::Vector{TimeUnitType{U}}) where {U <: Unitful.Units}
+        size(birth) == size(death) || ("Birth and death vector lengths differ")
+        new{U}(birth, death, virus_growth, virus_decay, beta_force, beta_env, sigma)
+    end
     function SIRGrowth{U}(birth::Vector{TimeUnitType{U}},
         death::Vector{TimeUnitType{U}}, virus_growth::TimeUnitType{U}, virus_decay::TimeUnitType{U}, beta_force::TimeUnitType{U}, beta_env::TimeUnitType{U}, sigma::TimeUnitType{U}) where {U <: Unitful.Units}
         length(birth) == length(death) || ("Birth and death vector lengths differ")
-        new{U}(birth, death, virus_growth, virus_decay, beta_force, beta_env, sigma)
+        new_birth = reshape(birth, length(birth), 1)
+        new_death = reshape(birth, length(death), 1)
+        new{U}(new_birth, new_death, [virus_growth], [virus_decay], [beta_force], [beta_env], [sigma])
     end
 end
 
@@ -26,19 +34,24 @@ end
 Parameter set that houses information on birth and death rates of different classes in an SIS model, as well as growth and decay of virus, and infection/recovery parameters.
 """
 mutable struct SISGrowth{U <: Unitful.Units} <: AbstractParams
-      birth::Vector{TimeUnitType{U}}
-      death::Vector{TimeUnitType{U}}
-      virus_growth::TimeUnitType{U}
-      virus_decay::TimeUnitType{U}
-      beta_force::TimeUnitType{U}
-      beta_env::TimeUnitType{U}
-      sigma::TimeUnitType{U}
-    function SISGrowth{U}(birth::Vector{TimeUnitType{U}},
-        death::Vector{TimeUnitType{U}}, virus_growth::TimeUnitType{U},
-        virus_decay::TimeUnitType{U}, beta_force::TimeUnitType{U}, beta_env::TimeUnitType{U},
-        sigma::TimeUnitType{U}) where {U <: Unitful.Units}
-        length(birth) == length(death) || ("Birth and death vector lengths differ")
+      birth::Matrix{TimeUnitType{U}}
+      death::Matrix{TimeUnitType{U}}
+      virus_growth::Vector{TimeUnitType{U}}
+      virus_decay::Vector{TimeUnitType{U}}
+      beta_force::Vector{TimeUnitType{U}}
+      beta_env::Vector{TimeUnitType{U}}
+      sigma::Vector{TimeUnitType{U}}
+    function SISGrowth{U}(birth::Matrix{TimeUnitType{U}},
+        death::Matrix{TimeUnitType{U}}, virus_growth::Vector{TimeUnitType{U}}, virus_decay::Vector{TimeUnitType{U}}, beta_force::Vector{TimeUnitType{U}}, beta_env::Vector{TimeUnitType{U}}, sigma::Vector{TimeUnitType{U}}) where {U <: Unitful.Units}
+        size(birth) == size(death) || ("Birth and death vector lengths differ")
         new{U}(birth, death, virus_growth, virus_decay, beta_force, beta_env, sigma)
+    end
+    function SISGrowth{U}(birth::Vector{TimeUnitType{U}},
+        death::Vector{TimeUnitType{U}}, virus_growth::TimeUnitType{U}, virus_decay::TimeUnitType{U}, beta_force::TimeUnitType{U}, beta_env::TimeUnitType{U}, sigma::TimeUnitType{U}) where {U <: Unitful.Units}
+        length(birth) == length(death) || ("Birth and death vector lengths differ")
+        new_birth = reshape(birth, length(birth), 1)
+        new_death = reshape(birth, length(death), 1)
+        new{U}(new_birth, new_death, [virus_growth], [virus_decay], [beta_force], [beta_env], [sigma])
     end
 end
 
@@ -48,20 +61,25 @@ end
 Parameter set that houses information on birth and death rates of different classes in an SEIR model, as well as growth and decay of virus, and infection/incubation/recovery parameters.
 """
 mutable struct SEIRGrowth{U <: Unitful.Units} <: AbstractParams
-      birth::Vector{TimeUnitType{U}}
-      death::Vector{TimeUnitType{U}}
-      virus_growth::TimeUnitType{U}
-      virus_decay::TimeUnitType{U}
-      beta_force::TimeUnitType{U}
-      beta_env::TimeUnitType{U}
-      mu::TimeUnitType{U}
-      sigma::TimeUnitType{U}
-    function SEIRGrowth{U}(birth::Vector{TimeUnitType{U}},
-        death::Vector{TimeUnitType{U}}, virus_growth::TimeUnitType{U},
-        virus_decay::TimeUnitType{U}, beta_force::TimeUnitType{U},
-        beta_env::TimeUnitType{U}, mu::TimeUnitType{U}, sigma::TimeUnitType{U}) where {U <: Unitful.Units}
-        length(birth) == length(death) || ("Birth and death vector lengths differ")
+      birth::Matrix{TimeUnitType{U}}
+      death::Matrix{TimeUnitType{U}}
+      virus_growth::Vector{TimeUnitType{U}}
+      virus_decay::Vector{TimeUnitType{U}}
+      beta_force::Vector{TimeUnitType{U}}
+      beta_env::Vector{TimeUnitType{U}}
+      mu::Vector{TimeUnitType{U}}
+      sigma::Vector{TimeUnitType{U}}
+    function SEIRGrowth{U}(birth::Matrix{TimeUnitType{U}},
+        death::Matrix{TimeUnitType{U}}, virus_growth::Vector{TimeUnitType{U}}, virus_decay::Vector{TimeUnitType{U}}, beta_force::Vector{TimeUnitType{U}}, beta_env::Vector{TimeUnitType{U}}, mu::Vector{TimeUnitType{U}}, sigma::Vector{TimeUnitType{U}}) where {U <: Unitful.Units}
+        size(birth) == size(death) || ("Birth and death vector lengths differ")
         new{U}(birth, death, virus_growth, virus_decay, beta_force, beta_env, mu, sigma)
+    end
+    function SEIRGrowth{U}(birth::Vector{TimeUnitType{U}},
+        death::Vector{TimeUnitType{U}}, virus_growth::TimeUnitType{U}, virus_decay::TimeUnitType{U}, beta_force::TimeUnitType{U}, beta_env::TimeUnitType{U}, mu::TimeUnitType{U}, sigma::TimeUnitType{U}) where {U <: Unitful.Units}
+        length(birth) == length(death) || ("Birth and death vector lengths differ")
+        new_birth = reshape(birth, length(birth), 1)
+        new_death = reshape(birth, length(death), 1)
+        new{U}(new_birth, new_death, [virus_growth], [virus_decay], [beta_force], [beta_env], [mu], [sigma])
     end
 end
 
@@ -71,21 +89,26 @@ end
 Parameter set that houses information on birth and death rates of different classes in an SEIRS model, as well as growth and decay of virus, and infection/incubation/recovery parameters.
 """
 mutable struct SEIRSGrowth{U <: Unitful.Units} <: AbstractParams
-      birth::Vector{TimeUnitType{U}}
-      death::Vector{TimeUnitType{U}}
-      virus_growth::TimeUnitType{U}
-      virus_decay::TimeUnitType{U}
-      beta_force::TimeUnitType{U}
-      beta_env::TimeUnitType{U}
-      mu::TimeUnitType{U}
-      epsilon::TimeUnitType{U}
-      sigma::TimeUnitType{U}
-    function SEIRSGrowth{U}(birth::Vector{TimeUnitType{U}},
-        death::Vector{TimeUnitType{U}}, virus_growth::TimeUnitType{U},
-        virus_decay::TimeUnitType{U}, beta_force::TimeUnitType{U}, beta_env::TimeUnitType{U},
-        mu::TimeUnitType{U}, sigma::TimeUnitType{U}, epsilon::TimeUnitType{U}) where {U <: Unitful.Units}
-        length(birth) == length(death) || ("Birth and death vector lengths differ")
+      birth::Matrix{TimeUnitType{U}}
+      death::Matrix{TimeUnitType{U}}
+      virus_growth::Vector{TimeUnitType{U}}
+      virus_decay::Vector{TimeUnitType{U}}
+      beta_force::Vector{TimeUnitType{U}}
+      beta_env::Vector{TimeUnitType{U}}
+      mu::Vector{TimeUnitType{U}}
+      sigma::Vector{TimeUnitType{U}}
+      epsilon::Vector{TimeUnitType{U}}
+    function SEIRSGrowth{U}(birth::Matrix{TimeUnitType{U}},
+        death::Matrix{TimeUnitType{U}}, virus_growth::Vector{TimeUnitType{U}}, virus_decay::Vector{TimeUnitType{U}}, beta_force::Vector{TimeUnitType{U}}, beta_env::Vector{TimeUnitType{U}}, mu::Vector{TimeUnitType{U}}, sigma::Vector{TimeUnitType{U}}, epsilon::Vector{TimeUnitType{U}}) where {U <: Unitful.Units}
+        size(birth) == size(death) || ("Birth and death vector lengths differ")
         new{U}(birth, death, virus_growth, virus_decay, beta_force, beta_env, mu, sigma, epsilon)
+    end
+    function SEIRSGrowth{U}(birth::Vector{TimeUnitType{U}},
+        death::Vector{TimeUnitType{U}}, virus_growth::TimeUnitType{U}, virus_decay::TimeUnitType{U}, beta_force::TimeUnitType{U}, beta_env::TimeUnitType{U}, mu::TimeUnitType{U}, sigma::TimeUnitType{U}, epsilon::TimeUnitType{U}) where {U <: Unitful.Units}
+        length(birth) == length(death) || ("Birth and death vector lengths differ")
+        new_birth = reshape(birth, length(birth), 1)
+        new_death = reshape(birth, length(death), 1)
+        new{U}(new_birth, new_death, [virus_growth], [virus_decay], [beta_force], [beta_env], [mu], [sigma], [epsilon])
     end
 end
 
@@ -95,30 +118,50 @@ end
 Parameter set that houses information on birth and death rates of different classes in an SEI2HRD model, as well as growth and decay of virus, and infection/incubation/hospitalisation/recovery parameters.
 """
 mutable struct SEI2HRDGrowth{U <: Unitful.Units} <: AbstractParams
-      birth::Vector{TimeUnitType{U}}
-      death::Vector{TimeUnitType{U}}
-      virus_growth::Vector{TimeUnitType{U}}
+      birth::Matrix{TimeUnitType{U}}
+      death::Matrix{TimeUnitType{U}}
+      virus_growth_asymp::Vector{TimeUnitType{U}}
+      virus_growth_symp::Vector{TimeUnitType{U}}
       virus_decay::Vector{TimeUnitType{U}}
-      beta_force::TimeUnitType{U}
-      beta_env::TimeUnitType{U}
-      sigma_1::TimeUnitType{U}
-      sigma_2::TimeUnitType{U}
-      sigma_hospital::TimeUnitType{U}
-      mu_1::TimeUnitType{U}
-      mu_2::TimeUnitType{U}
-      hospitalisation::TimeUnitType{U}
-      death_home::TimeUnitType{U}
-      death_hospital::TimeUnitType{U}
+      beta_force::Vector{TimeUnitType{U}}
+      beta_env::Vector{TimeUnitType{U}}
+      sigma_1::Vector{TimeUnitType{U}}
+      sigma_2::Vector{TimeUnitType{U}}
+      sigma_hospital::Vector{TimeUnitType{U}}
+      mu_1::Vector{TimeUnitType{U}}
+      mu_2::Vector{TimeUnitType{U}}
+      hospitalisation::Vector{TimeUnitType{U}}
+      death_home::Vector{TimeUnitType{U}}
+      death_hospital::Vector{TimeUnitType{U}}
+    function SEI2HRDGrowth{U}(birth::Matrix{TimeUnitType{U}},
+        death::Matrix{TimeUnitType{U}}, virus_growth_asymp::Vector{TimeUnitType{U}},
+        virus_growth_symp::Vector{TimeUnitType{U}}, virus_decay::Vector{TimeUnitType{U}}, beta_force::Vector{TimeUnitType{U}}, beta_env::Vector{TimeUnitType{U}}, sigma_1::Vector{TimeUnitType{U}},
+        sigma_2::Vector{TimeUnitType{U}},
+        sigma_hospital::Vector{TimeUnitType{U}},
+        mu_1::Vector{TimeUnitType{U}},
+        mu_2::Vector{TimeUnitType{U}},
+        hospitalisation::Vector{TimeUnitType{U}},
+        death_home::Vector{TimeUnitType{U}},
+        death_hospital::Vector{TimeUnitType{U}}) where {U <: Unitful.Units}
+        size(birth) == size(death) || ("Birth and death vector lengths differ")
+        all(beta_force .!= 0/day) & all(beta_env .!= 0/day) || warning("Transmission rates are zero.")
+        new{U}(birth, death, virus_growth_asymp, virus_growth_symp, virus_decay, beta_force, beta_env, mu, sigma)
+    end
     function SEI2HRDGrowth{U}(birth::Vector{TimeUnitType{U}},
-        death::Vector{TimeUnitType{U}}, virus_growth::Vector{TimeUnitType{U}},
-        virus_decay::Vector{TimeUnitType{U}}, beta_force::TimeUnitType{U}, beta_env::TimeUnitType{U},
-        sigma_1::TimeUnitType{U}, sigma_2::TimeUnitType{U}, sigma_hospital::TimeUnitType{U}, mu_1::TimeUnitType{U},
-        mu_2::TimeUnitType{U}, hospitalisation::TimeUnitType{U}, death_home::TimeUnitType{U},
+        death::Vector{TimeUnitType{U}}, virus_growth_asymp::TimeUnitType{U},
+        virus_growth_symp::TimeUnitType{U}, virus_decay::TimeUnitType{U}, beta_force::TimeUnitType{U}, beta_env::TimeUnitType{U}, sigma_1::TimeUnitType{U},
+        sigma_2::TimeUnitType{U},
+        sigma_hospital::TimeUnitType{U},
+        mu_1::TimeUnitType{U},
+        mu_2::TimeUnitType{U},
+        hospitalisation::TimeUnitType{U},
+        death_home::TimeUnitType{U},
         death_hospital::TimeUnitType{U}) where {U <: Unitful.Units}
         length(birth) == length(death) || ("Birth and death vector lengths differ")
-        length(virus_growth) == length(virus_decay) || ("Virus growth and decay vector lengths differ")
         (beta_force != 0/day) & (beta_env != 0/day) || warning("Transmission rate is zero.")
-        new{U}(birth, death, virus_growth, virus_decay, beta_force, beta_env, sigma_1, sigma_2, sigma_hospital, mu_1, mu_2, hospitalisation, death_home, death_hospital)
+        new_birth = reshape(birth, length(birth), 1)
+        new_death = reshape(birth, length(death), 1)
+        new{U}(new_birth, new_death, [virus_growth_asymp], [virus_growth_symp], [virus_decay], [beta_force], [beta_env], [sigma_1], [sigma_2], [sigma_hospital], [mu_1], [mu_2], [hospitalisation], [death_home], [death_hospital])
     end
 end
 
@@ -129,8 +172,9 @@ SEI2HRDGrowth(birth::Vector{TimeUnitType{U}},
 Function to calculate SEI2HRD parameters from initial probabilities of developing symptoms and needing hospitalisation, case fatality ratio, and time for transition between different categories.
 """
 function SEI2HRDGrowth(birth::Vector{TimeUnitType{U}},
-    death::Vector{TimeUnitType{U}}, virus_growth::Vector{TimeUnitType{U}},
-    virus_decay::Vector{TimeUnitType{U}}, beta_force::TimeUnitType{U}, beta_env::TimeUnitType{U},
+    death::Vector{TimeUnitType{U}}, virus_growth_asymp::TimeUnitType{U},
+    virus_growth_symp::TimeUnitType{U},
+    virus_decay::TimeUnitType{U}, beta_force::TimeUnitType{U}, beta_env::TimeUnitType{U},
     prob_sym::Float64, prob_hosp::Float64, cfr_home::Float64, cfr_hosp::Float64,
     T_lat::Unitful.Time, T_asym::Unitful.Time, T_sym::Unitful.Time,
     T_hosp::Unitful.Time, T_rec::Unitful.Time) where {U <: Unitful.Units}
@@ -150,8 +194,34 @@ function SEI2HRDGrowth(birth::Vector{TimeUnitType{U}},
     death_home = cfr_home * 2/T_hosp
     # Hospital -> death
     death_hospital = cfr_hosp * 1/T_hosp
-    return SEI2HRDGrowth{U}(birth, death, virus_growth, virus_decay, beta_force, beta_env,
+    return SEI2HRDGrowth{U}(birth, death, virus_growth_asymp, virus_growth_symp, virus_decay, beta_force, beta_env,
     sigma_1, sigma_2, sigma_hospital, mu_1, mu_2, hospitalisation, death_home, death_hospital)
+end
+
+function SEI2HRDGrowth(birth::Matrix{TimeUnitType{U}},
+    death::Matrix{TimeUnitType{U}}, virus_growth_asymp::Vector{TimeUnitType{U}},
+    virus_growth_symp::Vector{TimeUnitType{U}},
+    virus_decay::Vector{TimeUnitType{U}}, beta_force::Vector{TimeUnitType{U}}, beta_env::Vector{TimeUnitType{U}},
+    prob_sym::Vector{Float64}, prob_hosp::Vector{Float64}, cfr_home::Vector{Float64}, cfr_hosp::Vector{Float64},
+    T_lat::Unitful.Time, T_asym::Unitful.Time, T_sym::Unitful.Time,
+    T_hosp::Unitful.Time, T_rec::Unitful.Time) where {U <: Unitful.Units}
+    # Exposed -> asymptomatic
+    mu_1 = 1/T_lat
+    # Asymptomatic -> symptomatic
+    mu_2 = prob_sym .* 1/T_asym
+    # Symptomatic -> hospital
+    hospitalisation = prob_hosp .* 1/T_sym
+    # Asymptomatic -> recovered
+    sigma_1 = (1 .- prob_sym) .* 1/T_asym
+    # Symptomatic -> recovered
+    sigma_2 = (1 .- prob_hosp) .* (1 .- cfr_home) .* 1/T_rec
+    # Hospital -> recovered
+    sigma_hospital = (1 .- cfr_hosp) .* 1/T_hosp
+    # Symptomatic -> death
+    death_home = cfr_home .* 2/T_hosp
+    # Hospital -> death
+    death_hospital = cfr_hosp .* 1/T_hosp
+    return SEI2HRDGrowth{U}(birth, death, virus_growth_asymp, virus_growth_symp, beta_force, beta_env, sigma_1, sigma_2, sigma_hospital, mu_1, mu_2, hospitalisation, death_home, death_hospital)
 end
 
 """
@@ -180,19 +250,46 @@ end
 
 Function to create transition matrix from SIS parameters and return an `EpiParams` type that can be used by the model update.
 """
-function transition(params::SISGrowth)
-    tmat = zeros(typeof(params.beta_force), 4, 4)
-    tmat[end, :] .+= params.death
-    tmat[2, 3] = params.sigma
-    vmat = zeros(typeof(params.beta_force), 4, 4)
-    vfmat = zeros(typeof(params.beta_force), 4, 4)
-    vfmat[3, 2] = params.beta_force
-    vmat[3, 2] = params.beta_env
-    v_growth = fill(0.0 * unit(params.virus_growth), 5)
-    v_decay = fill(0.0 * unit(params.virus_growth), 5)
-    v_growth[3] = params.virus_growth
-    v_decay[3] = params.virus_decay
-  return EpiParams{typeof(unit(params.beta_force))}(params.birth, v_growth, v_decay, tmat, vfmat, vmat)
+function transition(params::SISGrowth, age_categories = 1)
+    # Set up number of classes etc
+    nclasses = 3
+    cat_idx = reshape(1:(nclasses * age_categories), age_categories, nclasses)
+
+    # Set up transition matrix
+    tm_size = nclasses * age_categories
+    tmat = zeros(typeof(params.beta_force[1]), tm_size, tm_size)
+
+    # Ageing
+    age_diag = diagind(tmat, -1)
+    tmat[age_diag] .= 1/365days
+    tmat[age_diag[age_categories:age_categories:end]] .= 0.0/day
+
+    # Death
+    for i in 1:(nclasses-1)
+        dmat = @view tmat[cat_idx[:, end], cat_idx[:, i]]
+        dmat[diagind(dmat)].= params.death[cat_idx[:, i]]
+    end
+
+    # Recovery
+    rmat = @view tmat[cat_idx[:, 2], cat_idx[:, 3]]
+    rmat[diagind(rmat)] .= params.sigma
+
+    # Env virus matrix
+    vmat = zeros(typeof(params.beta_force[1]), tm_size, tm_size)
+    bmat = @view vmat[cat_idx[:, 2], cat_idx[:, 1]]
+    bmat[diagind(bmat)] .= params.beta_env
+
+    # Force matrix
+    vfmat = zeros(typeof(params.beta_force[1]), tm_size, tm_size)
+    bmat = @view vfmat[cat_idx[:, 2], cat_idx[:, 1]]
+    bmat[diagind(bmat)] .= params.beta_force
+
+    # Virus growth and decay
+    v_growth = fill(0.0 * unit(params.virus_growth[1]), tm_size)
+    v_decay = fill(0.0 * unit(params.virus_growth[1]), tm_size)
+    v_growth[cat_idx[:, 2]] .= params.virus_growth
+    v_decay[cat_idx[:, 2]] .= params.virus_decay
+  return EpiParams{typeof(unit(params.beta_force[1]))}(params.birth[1:end], v_growth, v_decay, tmat, vfmat, vmat)
 end
 
 """
@@ -200,19 +297,46 @@ end
 
 Function to create transition matrix from SIR parameters and return an `EpiParams` type that can be used by the model update.
 """
-function transition(params::SIRGrowth)
-    tmat = zeros(typeof(params.beta_force), 5, 5)
-    tmat[4, 3] = params.sigma
-    tmat[end, :] .+= params.death
-    vmat = zeros(typeof(params.beta_force), 5, 5)
-    vfmat = zeros(typeof(params.beta_force), 5, 5)
-    vfmat[3, 2] = params.beta_force
-    vmat[3, 2] = params.beta_env
-    v_growth = fill(0.0 * unit(params.virus_growth), 5)
-    v_decay = fill(0.0 * unit(params.virus_growth), 5)
-    v_growth[3] = params.virus_growth
-    v_decay[3] = params.virus_decay
-  return EpiParams{typeof(unit(params.beta_force))}(params.birth, v_growth, v_decay, tmat, vfmat, vmat)
+function transition(params::SIRGrowth, age_categories = 1)
+    # Set up number of classes etc
+    nclasses = 4
+    cat_idx = reshape(1:(nclasses * age_categories), age_categories, nclasses)
+
+    # Set up transition matrix
+    tm_size = nclasses * age_categories
+    tmat = zeros(typeof(params.beta_force[1]), tm_size, tm_size)
+
+    # Ageing
+    age_diag = diagind(tmat, -1)
+    tmat[age_diag] .= 1/365days
+    tmat[age_diag[age_categories:age_categories:end]] .= 0.0/day
+
+    # Death
+    for i in 1:(nclasses-1)
+        dmat = @view tmat[cat_idx[:, end], cat_idx[:, i]]
+        dmat[diagind(dmat)].= params.death[cat_idx[:, i]]
+    end
+
+    # Recovery
+    rmat = @view tmat[cat_idx[:, 3], cat_idx[:, 2]]
+    rmat[diagind(rmat)] .= params.sigma
+
+    # Env virus matrix
+    vmat = zeros(typeof(params.beta_force[1]), tm_size, tm_size)
+    bmat = @view vmat[cat_idx[:, 2], cat_idx[:, 1]]
+    bmat[diagind(bmat)] .= params.beta_env
+
+    # Force matrix
+    vfmat = zeros(typeof(params.beta_force[1]), tm_size, tm_size)
+    bmat = @view vfmat[cat_idx[:, 2], cat_idx[:, 1]]
+    bmat[diagind(bmat)] .= params.beta_force
+
+    # Virus growth and decay
+    v_growth = fill(0.0 * unit(params.virus_growth[1]), tm_size)
+    v_decay = fill(0.0 * unit(params.virus_growth[1]), tm_size)
+    v_growth[cat_idx[:, 2]] .= params.virus_growth
+    v_decay[cat_idx[:, 2]] .= params.virus_decay
+  return EpiParams{typeof(unit(params.beta_force[1]))}(params.birth[1:end], v_growth, v_decay, tmat, vfmat, vmat)
 end
 
 """
@@ -220,24 +344,50 @@ end
 
 Function to create transition matrix from SEIR parameters and return an `EpiParams` type that can be used by the model update.
 """
-function transition(params::SEIRGrowth)
-    tmat = zeros(typeof(params.beta_force), 6, 6)
-    ordered_transitions = [params.mu, params.sigma]
-    from = [3, 4]
-    to = [4, 5]
-    for i in eachindex(to)
-            tmat[to[i], from[i]] = ordered_transitions[i]
+function transition(params::SEIRGrowth, age_categories = 1)
+    # Set up number of classes etc
+    nclasses = 5
+    cat_idx = reshape(1:(nclasses * age_categories), age_categories, nclasses)
+
+    # Set up transition matrix
+    tm_size = nclasses * age_categories
+    tmat = zeros(typeof(params.beta_force[1]), tm_size, tm_size)
+
+    # Ageing
+    age_diag = diagind(tmat, -1)
+    tmat[age_diag] .= 1/365days
+    tmat[age_diag[age_categories:age_categories:end]] .= 0.0/day
+
+    # Death
+    for i in 1:(nclasses-1)
+        dmat = @view tmat[cat_idx[:, end], cat_idx[:, i]]
+        dmat[diagind(dmat)].= params.death[cat_idx[:, i]]
     end
-    tmat[end, :] .+= params.death
-    vmat = zeros(typeof(params.beta_force), 6, 6)
-    vfmat = zeros(typeof(params.beta_force), 6, 6)
-    vfmat[3, 2] = params.beta_force
-    vmat[3, 2] = params.beta_env
-    v_growth = fill(0.0 * unit(params.virus_growth), 6)
-    v_decay = fill(0.0 * unit(params.virus_growth), 6)
-    v_growth[4] = params.virus_growth
-    v_decay[4] = params.virus_decay
-  return EpiParams{typeof(unit(params.beta_force))}(params.birth, v_growth, v_decay, tmat, vfmat, vmat)
+
+    # Incubation
+    imat = @view tmat[cat_idx[:, 3], cat_idx[:, 2]]
+    imat[diagind(imat)] .= params.mu
+
+    # Recovery
+    rmat = @view tmat[cat_idx[:, 4], cat_idx[:, 3]]
+    rmat[diagind(rmat)] .= params.sigma
+
+    # Env virus matrix
+    vmat = zeros(typeof(params.beta_force[1]), tm_size, tm_size)
+    bmat = @view vmat[cat_idx[:, 2], cat_idx[:, 1]]
+    bmat[diagind(bmat)] .= params.beta_env
+
+    # Force matrix
+    vfmat = zeros(typeof(params.beta_force[1]), tm_size, tm_size)
+    bmat = @view vfmat[cat_idx[:, 2], cat_idx[:, 1]]
+    bmat[diagind(bmat)] .= params.beta_force
+
+    # Virus growth and decay
+    v_growth = fill(0.0 * unit(params.virus_growth[1]), tm_size)
+    v_decay = fill(0.0 * unit(params.virus_growth[1]), tm_size)
+    v_growth[cat_idx[:, 3]] .= params.virus_growth
+    v_decay[cat_idx[:, 3]] .= params.virus_decay
+  return EpiParams{typeof(unit(params.beta_force[1]))}(params.birth[1:end], v_growth, v_decay, tmat, vfmat, vmat)
 end
 
 """
@@ -245,24 +395,54 @@ end
 
 Function to create transition matrix from SEIRS parameters and return an `EpiParams` type that can be used by the model update.
 """
-function transition(params::SEIRSGrowth)
-    tmat = zeros(typeof(params.beta_force), 6, 6)
-    ordered_transitions = [params.mu, params.sigma, params.epsilon]
-    from = [3, 4, 5]
-    to = [4, 5, 2]
-    for i in eachindex(to)
-            tmat[to[i], from[i]] = ordered_transitions[i]
+function transition(params::SEIRSGrowth, age_categories = 1)
+    # Set up number of classes etc
+    nclasses = 5
+    cat_idx = reshape(1:(nclasses * age_categories), age_categories, nclasses)
+
+    # Set up transition matrix
+    tm_size = nclasses * age_categories
+    tmat = zeros(typeof(params.beta_force[1]), tm_size, tm_size)
+
+    # Ageing
+    age_diag = diagind(tmat, -1)
+    tmat[age_diag] .= 1/365days
+    tmat[age_diag[age_categories:age_categories:end]] .= 0.0/day
+
+    # Death
+    for i in 1:(nclasses-1)
+        dmat = @view tmat[cat_idx[:, end], cat_idx[:, i]]
+        dmat[diagind(dmat)].= params.death[cat_idx[:, i]]
     end
-    tmat[end, :] .+= params.death
-    vmat = zeros(typeof(params.beta_force), 6, 6)
-    vfmat = zeros(typeof(params.beta_force), 6, 6)
-    vfmat[3, 2] = params.beta_force
-    vmat[3, 2] = params.beta_env
-    v_growth = fill(0.0 * unit(params.virus_growth), 6)
-    v_decay = fill(0.0 * unit(params.virus_growth), 6)
-    v_growth[4] = params.virus_growth
-    v_decay[4] = params.virus_decay
-  return EpiParams{typeof(unit(params.beta_force))}(params.birth, v_growth, v_decay, tmat, vfmat, vmat)
+
+    # Incubation
+    imat = @view tmat[cat_idx[:, 3], cat_idx[:, 2]]
+    imat[diagind(imat)] .= params.mu
+
+    # Recovery
+    rmat = @view tmat[cat_idx[:, 4], cat_idx[:, 3]]
+    rmat[diagind(rmat)] .= params.sigma
+
+    # Immunity waning
+    rmat = @view tmat[cat_idx[:, 1], cat_idx[:, 4]]
+    rmat[diagind(rmat)] .= params.epsilon
+
+    # Env virus matrix
+    vmat = zeros(typeof(params.beta_force[1]), tm_size, tm_size)
+    bmat = @view vmat[cat_idx[:, 2], cat_idx[:, 1]]
+    bmat[diagind(bmat)] .= params.beta_env
+
+    # Force matrix
+    vfmat = zeros(typeof(params.beta_force[1]), tm_size, tm_size)
+    bmat = @view vfmat[cat_idx[:, 2], cat_idx[:, 1]]
+    bmat[diagind(bmat)] .= params.beta_force
+
+    # Virus growth and decay
+    v_growth = fill(0.0 * unit(params.virus_growth[1]), tm_size)
+    v_decay = fill(0.0 * unit(params.virus_growth[1]), tm_size)
+    v_growth[cat_idx[:, 3]] .= params.virus_growth
+    v_decay[cat_idx[:, 3]] .= params.virus_decay
+  return EpiParams{typeof(unit(params.beta_force[1]))}(params.birth[1:end], v_growth, v_decay, tmat, vfmat, vmat)
 end
 
 """
@@ -270,19 +450,50 @@ end
 
 Function to create transition matrix from SEI2HRD parameters and return an `EpiParams` type that can be used by the model update.
 """
-function transition(params::SEI2HRDGrowth)
+function transition(params::SEI2HRDGrowth, age_categories = 1)
+    # Set up number of classes etc
+    nclasses = 7
+    cat_idx = reshape(1:(nclasses * age_categories), age_categories, nclasses)
+
+    # Set up transition matrix
+    tm_size = nclasses * age_categories
+    tmat = zeros(typeof(params.beta_force[1]), tm_size, tm_size)
+
+    # Ageing
+    age_diag = diagind(tmat, -1)
+    tmat[age_diag] .= 1/365days
+    tmat[age_diag[age_categories:age_categories:end]] .= 0.0/day
+
+    # Death
+    for i in 1:(nclasses-1)
+        dmat = @view tmat[cat_idx[:, end], cat_idx[:, i]]
+        dmat[diagind(dmat)].= params.death[cat_idx[:, i]]
+    end
+
     ordered_transitions = (incubation_period = params.mu_1, symptoms_develop = params.mu_2, symptoms_worsen = params.hospitalisation, recovery_asymptomatic = params.sigma_1, recovery_symptomatic = params.sigma_2, recovery_hospital = params.sigma_hospital, death_symptomatic = params.death_home,
     death_hospitalised = params.death_hospital)
-    from = [3, 4, 5, 4, 5, 6, 5, 6]
-    to = [4, 5, 6, 7, 7, 7, 8, 8]
-    tmat = zeros(typeof(params.beta_force), 8, 8)
+    from = [2, 3, 4, 3, 4, 5, 4, 5]
+    to = [3, 4, 5, 6, 6, 6, 7, 7]
     for i in eachindex(to)
-            tmat[to[i], from[i]] = ordered_transitions[i]
+            view_mat = @view tmat[cat_idx[:, to[i]], cat_idx[:, from[i]]]
+            view_mat[diagind(view_mat)] .= ordered_transitions[i]
     end
-    vmat = zeros(typeof(params.beta_force), 8, 8)
-    vfmat = zeros(typeof(params.beta_force), 8, 8)
-    vfmat[3, 2] = params.beta_force
-    vmat[3, 2] = params.beta_env
-    tmat[end, :] .+= params.death
-  return EpiParams{typeof(unit(params.beta_force))}(params.birth, params.virus_growth, params.virus_decay, tmat, vfmat, vmat)
+
+    # Env virus matrix
+    vmat = zeros(typeof(params.beta_force[1]), tm_size, tm_size)
+    bmat = @view vmat[cat_idx[:, 2], cat_idx[:, 1]]
+    bmat[diagind(bmat)] .= params.beta_env
+
+    # Force matrix
+    vfmat = zeros(typeof(params.beta_force[1]), tm_size, tm_size)
+    bmat = @view vfmat[cat_idx[:, 2], cat_idx[:, 1]]
+    bmat[diagind(bmat)] .= params.beta_force
+
+    # Virus growth and decay
+    v_growth = fill(0.0 * unit(params.virus_growth_asymp[1]), tm_size)
+    v_decay = fill(0.0 * unit(params.virus_growth_asymp[1]), tm_size)
+    v_growth[cat_idx[:, 3]] .= params.virus_growth_asymp
+    v_growth[cat_idx[:, 4]] .= params.virus_growth_symp
+    v_decay[cat_idx[:, 3]] .= params.virus_decay
+  return EpiParams{typeof(unit(params.beta_force[1]))}(params.birth[1:end], v_growth, v_decay, tmat, vfmat, vmat)
 end

--- a/src/Epidemiology/EpiParams.jl
+++ b/src/Epidemiology/EpiParams.jl
@@ -1,5 +1,6 @@
 using Unitful
 using LinearAlgebra
+using DataFrames
 
 """
     SIRGrowth{U <: Unitful.Units} <: AbstractParams
@@ -11,14 +12,14 @@ mutable struct SIRGrowth{U <: Unitful.Units} <: AbstractParams
       death::Matrix{TimeUnitType{U}}
       ageing::Vector{TimeUnitType{U}}
       virus_growth::Vector{TimeUnitType{U}}
-      virus_decay::Vector{TimeUnitType{U}}
+      virus_decay::TimeUnitType{U}
       beta_force::Vector{TimeUnitType{U}}
       beta_env::Vector{TimeUnitType{U}}
       sigma::Vector{TimeUnitType{U}}
 
     # Multiple age categories
     function SIRGrowth{U}(birth::Matrix{TimeUnitType{U}},
-        death::Matrix{TimeUnitType{U}}, ageing::Vector{TimeUnitType{U}}, virus_growth::Vector{TimeUnitType{U}}, virus_decay::Vector{TimeUnitType{U}}, beta_force::Vector{TimeUnitType{U}}, beta_env::Vector{TimeUnitType{U}}, sigma::Vector{TimeUnitType{U}}) where {U <: Unitful.Units}
+        death::Matrix{TimeUnitType{U}}, ageing::Vector{TimeUnitType{U}}, virus_growth::Vector{TimeUnitType{U}}, virus_decay::TimeUnitType{U}, beta_force::Vector{TimeUnitType{U}}, beta_env::Vector{TimeUnitType{U}}, sigma::Vector{TimeUnitType{U}}) where {U <: Unitful.Units}
 
         size(birth) == size(death) || error("Birth and death vector lengths differ")
         all(beta_force .!= 0/day) & all(beta_env .!= 0/day) || warning("Transmission rates are zero.")
@@ -36,7 +37,7 @@ mutable struct SIRGrowth{U <: Unitful.Units} <: AbstractParams
         new_birth = reshape(birth, length(birth), 1)
         new_death = reshape(birth, length(death), 1)
         ageing = [0.0/day]
-        return new{U}(new_birth, new_death, ageing, [virus_growth], [virus_decay], [beta_force], [beta_env], [sigma])
+        return new{U}(new_birth, new_death, ageing, [virus_growth], virus_decay, [beta_force], [beta_env], [sigma])
     end
 end
 
@@ -50,14 +51,14 @@ mutable struct SISGrowth{U <: Unitful.Units} <: AbstractParams
       death::Matrix{TimeUnitType{U}}
       ageing::Vector{TimeUnitType{U}}
       virus_growth::Vector{TimeUnitType{U}}
-      virus_decay::Vector{TimeUnitType{U}}
+      virus_decay::TimeUnitType{U}
       beta_force::Vector{TimeUnitType{U}}
       beta_env::Vector{TimeUnitType{U}}
       sigma::Vector{TimeUnitType{U}}
 
     # Multiple age categories
     function SISGrowth{U}(birth::Matrix{TimeUnitType{U}},
-        death::Matrix{TimeUnitType{U}}, ageing::Vector{TimeUnitType{U}}, virus_growth::Vector{TimeUnitType{U}}, virus_decay::Vector{TimeUnitType{U}}, beta_force::Vector{TimeUnitType{U}}, beta_env::Vector{TimeUnitType{U}}, sigma::Vector{TimeUnitType{U}}) where {U <: Unitful.Units}
+        death::Matrix{TimeUnitType{U}}, ageing::Vector{TimeUnitType{U}}, virus_growth::Vector{TimeUnitType{U}}, virus_decay::TimeUnitType{U}, beta_force::Vector{TimeUnitType{U}}, beta_env::Vector{TimeUnitType{U}}, sigma::Vector{TimeUnitType{U}}) where {U <: Unitful.Units}
 
         size(birth) == size(death) || error("Birth and death vector lengths differ")
         all(beta_force .!= 0/day) & all(beta_env .!= 0/day) || warning("Transmission rates are zero.")
@@ -75,7 +76,7 @@ mutable struct SISGrowth{U <: Unitful.Units} <: AbstractParams
         new_birth = reshape(birth, length(birth), 1)
         new_death = reshape(birth, length(death), 1)
         ageing = [0.0/day]
-        return new{U}(new_birth, new_death, ageing, [virus_growth], [virus_decay], [beta_force], [beta_env], [sigma])
+        return new{U}(new_birth, new_death, ageing, [virus_growth], virus_decay, [beta_force], [beta_env], [sigma])
     end
 end
 
@@ -89,7 +90,7 @@ mutable struct SEIRGrowth{U <: Unitful.Units} <: AbstractParams
       death::Matrix{TimeUnitType{U}}
       ageing::Vector{TimeUnitType{U}}
       virus_growth::Vector{TimeUnitType{U}}
-      virus_decay::Vector{TimeUnitType{U}}
+      virus_decay::TimeUnitType{U}
       beta_force::Vector{TimeUnitType{U}}
       beta_env::Vector{TimeUnitType{U}}
       mu::Vector{TimeUnitType{U}}
@@ -98,7 +99,7 @@ mutable struct SEIRGrowth{U <: Unitful.Units} <: AbstractParams
     # Multiple age categories
     function SEIRGrowth{U}(birth::Matrix{TimeUnitType{U}},
         death::Matrix{TimeUnitType{U}},
-        ageing::Vector{TimeUnitType{U}},  virus_growth::Vector{TimeUnitType{U}}, virus_decay::Vector{TimeUnitType{U}}, beta_force::Vector{TimeUnitType{U}}, beta_env::Vector{TimeUnitType{U}}, mu::Vector{TimeUnitType{U}}, sigma::Vector{TimeUnitType{U}}) where {U <: Unitful.Units}
+        ageing::Vector{TimeUnitType{U}},  virus_growth::Vector{TimeUnitType{U}}, virus_decay::TimeUnitType{U}, beta_force::Vector{TimeUnitType{U}}, beta_env::Vector{TimeUnitType{U}}, mu::Vector{TimeUnitType{U}}, sigma::Vector{TimeUnitType{U}}) where {U <: Unitful.Units}
 
         size(birth) == size(death) || error("Birth and death vector lengths differ")
         all(beta_force .!= 0/day) & all(beta_env .!= 0/day) || warning("Transmission rates are zero.")
@@ -116,7 +117,7 @@ mutable struct SEIRGrowth{U <: Unitful.Units} <: AbstractParams
         new_birth = reshape(birth, length(birth), 1)
         new_death = reshape(birth, length(death), 1)
         ageing = [0.0/day]
-        return new{U}(new_birth, new_death, ageing, [virus_growth], [virus_decay], [beta_force], [beta_env], [mu], [sigma])
+        return new{U}(new_birth, new_death, ageing, [virus_growth], virus_decay, [beta_force], [beta_env], [mu], [sigma])
     end
 end
 
@@ -130,7 +131,7 @@ mutable struct SEIRSGrowth{U <: Unitful.Units} <: AbstractParams
       death::Matrix{TimeUnitType{U}}
       ageing::Vector{TimeUnitType{U}}
       virus_growth::Vector{TimeUnitType{U}}
-      virus_decay::Vector{TimeUnitType{U}}
+      virus_decay::TimeUnitType{U}
       beta_force::Vector{TimeUnitType{U}}
       beta_env::Vector{TimeUnitType{U}}
       mu::Vector{TimeUnitType{U}}
@@ -140,7 +141,7 @@ mutable struct SEIRSGrowth{U <: Unitful.Units} <: AbstractParams
     # Multiple age categories
     function SEIRSGrowth{U}(birth::Matrix{TimeUnitType{U}},
         death::Matrix{TimeUnitType{U}},
-        ageing::Vector{TimeUnitType{U}}, virus_growth::Vector{TimeUnitType{U}}, virus_decay::Vector{TimeUnitType{U}}, beta_force::Vector{TimeUnitType{U}}, beta_env::Vector{TimeUnitType{U}}, mu::Vector{TimeUnitType{U}}, sigma::Vector{TimeUnitType{U}}, epsilon::Vector{TimeUnitType{U}}) where {U <: Unitful.Units}
+        ageing::Vector{TimeUnitType{U}}, virus_growth::Vector{TimeUnitType{U}}, virus_decay::TimeUnitType{U}, beta_force::Vector{TimeUnitType{U}}, beta_env::Vector{TimeUnitType{U}}, mu::Vector{TimeUnitType{U}}, sigma::Vector{TimeUnitType{U}}, epsilon::Vector{TimeUnitType{U}}) where {U <: Unitful.Units}
 
         size(birth) == size(death) || error("Birth and death vector lengths differ")
         all(beta_force .!= 0/day) & all(beta_env .!= 0/day) || warning("Transmission rates are zero.")
@@ -158,7 +159,7 @@ mutable struct SEIRSGrowth{U <: Unitful.Units} <: AbstractParams
         new_birth = reshape(birth, length(birth), 1)
         new_death = reshape(birth, length(death), 1)
         ageing = [0.0/day]
-        return new{U}(new_birth, new_death, ageing, [virus_growth], [virus_decay], [beta_force], [beta_env], [mu], [sigma], [epsilon])
+        return new{U}(new_birth, new_death, ageing, [virus_growth], virus_decay, [beta_force], [beta_env], [mu], [sigma], [epsilon])
     end
 end
 
@@ -173,7 +174,7 @@ mutable struct SEI2HRDGrowth{U <: Unitful.Units} <: AbstractParams
       ageing::Vector{TimeUnitType{U}}
       virus_growth_asymp::Vector{TimeUnitType{U}}
       virus_growth_symp::Vector{TimeUnitType{U}}
-      virus_decay::Vector{TimeUnitType{U}}
+      virus_decay::TimeUnitType{U}
       beta_force::Vector{TimeUnitType{U}}
       beta_env::Vector{TimeUnitType{U}}
       sigma_1::Vector{TimeUnitType{U}}
@@ -189,7 +190,7 @@ mutable struct SEI2HRDGrowth{U <: Unitful.Units} <: AbstractParams
     function SEI2HRDGrowth{U}(birth::Matrix{TimeUnitType{U}},
         death::Matrix{TimeUnitType{U}},
         ageing::Vector{TimeUnitType{U}}, virus_growth_asymp::Vector{TimeUnitType{U}},
-        virus_growth_symp::Vector{TimeUnitType{U}}, virus_decay::Vector{TimeUnitType{U}}, beta_force::Vector{TimeUnitType{U}}, beta_env::Vector{TimeUnitType{U}}, sigma_1::Vector{TimeUnitType{U}},
+        virus_growth_symp::Vector{TimeUnitType{U}}, virus_decay::TimeUnitType{U}, beta_force::Vector{TimeUnitType{U}}, beta_env::Vector{TimeUnitType{U}}, sigma_1::Vector{TimeUnitType{U}},
         sigma_2::Vector{TimeUnitType{U}},
         sigma_hospital::Vector{TimeUnitType{U}},
         mu_1::Vector{TimeUnitType{U}},
@@ -222,7 +223,7 @@ mutable struct SEI2HRDGrowth{U <: Unitful.Units} <: AbstractParams
         new_birth = reshape(birth, length(birth), 1)
         new_death = reshape(birth, length(death), 1)
         ageing = [0.0/day]
-        return new{U}(new_birth, new_death, ageing, [virus_growth_asymp], [virus_growth_symp], [virus_decay], [beta_force], [beta_env], [sigma_1], [sigma_2], [sigma_hospital], [mu_1], [mu_2], [hospitalisation], [death_home], [death_hospital])
+        return new{U}(new_birth, new_death, ageing, [virus_growth_asymp], [virus_growth_symp], virus_decay, [beta_force], [beta_env], [sigma_1], [sigma_2], [sigma_hospital], [mu_1], [mu_2], [hospitalisation], [death_home], [death_hospital])
     end
 end
 
@@ -263,7 +264,7 @@ function SEI2HRDGrowth(birth::Matrix{TimeUnitType{U}},
     death::Matrix{TimeUnitType{U}},
     ageing::Vector{TimeUnitType{U}},  virus_growth_asymp::Vector{TimeUnitType{U}},
     virus_growth_symp::Vector{TimeUnitType{U}},
-    virus_decay::Vector{TimeUnitType{U}}, beta_force::Vector{TimeUnitType{U}}, beta_env::Vector{TimeUnitType{U}},
+    virus_decay::TimeUnitType{U}, beta_force::Vector{TimeUnitType{U}}, beta_env::Vector{TimeUnitType{U}},
     prob_sym::Vector{Float64}, prob_hosp::Vector{Float64}, cfr_home::Vector{Float64}, cfr_hosp::Vector{Float64},
     T_lat::Unitful.Time, T_asym::Unitful.Time, T_sym::Unitful.Time,
     T_hosp::Unitful.Time, T_rec::Unitful.Time) where {U <: Unitful.Units}
@@ -307,30 +308,13 @@ mutable struct EpiParams{U <: Unitful.Units} <: AbstractParams
     end
 end
 
-# function transition(paramDat::DataFrame, age_categories::Int64, nclasses::Int64)
-#     # Set up number of classes etc
-#     nclasses = 3
-#     cat_idx = reshape(1:(nclasses * age_categories), age_categories, nclasses)
-#
-#     # Set up transition matrix
-#     tm_size = nclasses * age_categories
-#     tmat = zeros(typeof(params.beta_force[1]), tm_size, tm_size)
-#
-#
-# end
-"""
-    transition(params::SISGrowth)
-
-Function to create transition matrix from SIS parameters and return an `EpiParams` type that can be used by the model update.
-"""
-function transition(params::SISGrowth, age_categories = 1)
+function create_transition_matrix(params::AbstractParams, paramDat::DataFrame, age_categories::Int64, nclasses::Int64)
     # Set up number of classes etc
-    nclasses = 3
     cat_idx = reshape(1:(nclasses * age_categories), age_categories, nclasses)
 
     # Set up transition matrix
     tm_size = nclasses * age_categories
-    tmat = zeros(typeof(params.beta_force[1]), tm_size, tm_size)
+    tmat = zeros(typeof(paramDat[1, :param][1]), tm_size, tm_size)
 
     # Ageing
     for i in 1:(nclasses-1)
@@ -344,25 +328,59 @@ function transition(params::SISGrowth, age_categories = 1)
         dmat[diagind(dmat)].= params.death[cat_idx[:, i]]
     end
 
-    # Recovery
-    rmat = @view tmat[cat_idx[:, 2], cat_idx[:, 3]]
-    rmat[diagind(rmat)] .= params.sigma
+    # Other transitions
+    ordered_transitions = paramDat[!, :param]
+    from = paramDat[!, :from]
+    to = paramDat[!, :to]
+    for i in eachindex(to)
+            view_mat = @view tmat[cat_idx[:, to[i]], cat_idx[:, from[i]]]
+            view_mat[diagind(view_mat)] .= ordered_transitions[i]
+    end
+    return tmat
+end
+
+function create_virus_matrix(beta::Vector{TimeUnitType{U}}, age_categories::Int64, nclasses::Int64) where U <: Unitful.Units
+    cat_idx = reshape(1:(nclasses * age_categories), age_categories, nclasses)
+    vm_size = nclasses * age_categories
+    vmat = zeros(typeof(beta[1]), vm_size, vm_size)
+    bmat = @view vmat[cat_idx[:, 2], cat_idx[:, 1]]
+    bmat[diagind(bmat)] .= beta
+    return vmat
+end
+
+function create_virus_vector(virus_growth::Vector{TimeUnitType{U}}, virus_decay::TimeUnitType{U}, age_categories::Int64, nclasses::Int64, inf_cat::Int64) where U <: Unitful.Units
+    cat_idx = reshape(1:(nclasses * age_categories), age_categories, nclasses)
+    vm_size = nclasses * age_categories
+    v_growth = fill(0.0 * unit(virus_decay), vm_size)
+    v_decay = fill(0.0 * unit(virus_decay), vm_size)
+    v_growth[cat_idx[:, inf_cat]] .= virus_growth
+    v_decay[cat_idx[1, inf_cat]] = virus_decay
+    return v_growth, v_decay
+end
+"""
+    transition(params::SISGrowth)
+
+Function to create transition matrix from SIS parameters and return an `EpiParams` type that can be used by the model update.
+"""
+function transition(params::SISGrowth, age_categories = 1)
+    # Set up number of classes etc
+    nclasses = 3
+
+    from = 2
+    to = 1
+    paramDat = DataFrame(from = from, to = to, param = params.sigma)
+
+    tmat = create_transition_matrix(params, paramDat, age_categories, nclasses)
 
     # Env virus matrix
-    vmat = zeros(typeof(params.beta_force[1]), tm_size, tm_size)
-    bmat = @view vmat[cat_idx[:, 2], cat_idx[:, 1]]
-    bmat[diagind(bmat)] .= params.beta_env
+    vmat = create_virus_matrix(params.beta_env, age_categories, nclasses)
 
     # Force matrix
-    vfmat = zeros(typeof(params.beta_force[1]), tm_size, tm_size)
-    bmat = @view vfmat[cat_idx[:, 2], cat_idx[:, 1]]
-    bmat[diagind(bmat)] .= params.beta_force
+    vfmat = create_virus_matrix(params.beta_force, age_categories, nclasses)
 
     # Virus growth and decay
-    v_growth = fill(0.0 * unit(params.virus_growth[1]), tm_size)
-    v_decay = fill(0.0 * unit(params.virus_growth[1]), tm_size)
-    v_growth[cat_idx[:, 2]] .= params.virus_growth
-    v_decay[cat_idx[:, 2]] .= params.virus_decay
+    v_growth, v_decay = create_virus_vector(params.virus_growth, params.virus_decay, age_categories, nclasses, 2)
+
   return EpiParams{typeof(unit(params.beta_force[1]))}(params.birth[1:end], v_growth, v_decay, tmat, vfmat, vmat)
 end
 
@@ -374,43 +392,22 @@ Function to create transition matrix from SIR parameters and return an `EpiParam
 function transition(params::SIRGrowth, age_categories = 1)
     # Set up number of classes etc
     nclasses = 4
-    cat_idx = reshape(1:(nclasses * age_categories), age_categories, nclasses)
 
-    # Set up transition matrix
-    tm_size = nclasses * age_categories
-    tmat = zeros(typeof(params.beta_force[1]), tm_size, tm_size)
+    from = 2
+    to = 3
+    paramDat = DataFrame(from = from, to = to, param = params.sigma)
 
-    # Ageing
-    for i in 1:(nclasses-1)
-        amat = @view tmat[cat_idx[:, i], cat_idx[:, i]]
-        amat[diagind(amat, -1)].= params.ageing
-    end
-
-    # Death
-    for i in 1:(nclasses-1)
-        dmat = @view tmat[cat_idx[:, end], cat_idx[:, i]]
-        dmat[diagind(dmat)].= params.death[cat_idx[:, i]]
-    end
-
-    # Recovery
-    rmat = @view tmat[cat_idx[:, 3], cat_idx[:, 2]]
-    rmat[diagind(rmat)] .= params.sigma
+    tmat = create_transition_matrix(params, paramDat, age_categories, nclasses)
 
     # Env virus matrix
-    vmat = zeros(typeof(params.beta_force[1]), tm_size, tm_size)
-    bmat = @view vmat[cat_idx[:, 2], cat_idx[:, 1]]
-    bmat[diagind(bmat)] .= params.beta_env
+    vmat = create_virus_matrix(params.beta_env, age_categories, nclasses)
 
     # Force matrix
-    vfmat = zeros(typeof(params.beta_force[1]), tm_size, tm_size)
-    bmat = @view vfmat[cat_idx[:, 2], cat_idx[:, 1]]
-    bmat[diagind(bmat)] .= params.beta_force
+    vfmat = create_virus_matrix(params.beta_force, age_categories, nclasses)
 
     # Virus growth and decay
-    v_growth = fill(0.0 * unit(params.virus_growth[1]), tm_size)
-    v_decay = fill(0.0 * unit(params.virus_growth[1]), tm_size)
-    v_growth[cat_idx[:, 2]] .= params.virus_growth
-    v_decay[cat_idx[:, 2]] .= params.virus_decay
+    v_growth, v_decay = create_virus_vector(params.virus_growth, params.virus_decay, age_categories, nclasses, 2)
+
   return EpiParams{typeof(unit(params.beta_force[1]))}(params.birth[1:end], v_growth, v_decay, tmat, vfmat, vmat)
 end
 
@@ -422,47 +419,22 @@ Function to create transition matrix from SEIR parameters and return an `EpiPara
 function transition(params::SEIRGrowth, age_categories = 1)
     # Set up number of classes etc
     nclasses = 5
-    cat_idx = reshape(1:(nclasses * age_categories), age_categories, nclasses)
 
-    # Set up transition matrix
-    tm_size = nclasses * age_categories
-    tmat = zeros(typeof(params.beta_force[1]), tm_size, tm_size)
+    from = [2, 3]
+    to = [3, 4]
+    paramDat = DataFrame(from = from, to = to, param = [params.mu, params.sigma])
 
-    # Ageing
-    for i in 1:(nclasses-1)
-        amat = @view tmat[cat_idx[:, i], cat_idx[:, i]]
-        amat[diagind(amat, -1)].= params.ageing
-    end
-
-    # Death
-    for i in 1:(nclasses-1)
-        dmat = @view tmat[cat_idx[:, end], cat_idx[:, i]]
-        dmat[diagind(dmat)].= params.death[cat_idx[:, i]]
-    end
-
-    # Incubation
-    imat = @view tmat[cat_idx[:, 3], cat_idx[:, 2]]
-    imat[diagind(imat)] .= params.mu
-
-    # Recovery
-    rmat = @view tmat[cat_idx[:, 4], cat_idx[:, 3]]
-    rmat[diagind(rmat)] .= params.sigma
+    tmat = create_transition_matrix(params, paramDat, age_categories, nclasses)
 
     # Env virus matrix
-    vmat = zeros(typeof(params.beta_force[1]), tm_size, tm_size)
-    bmat = @view vmat[cat_idx[:, 2], cat_idx[:, 1]]
-    bmat[diagind(bmat)] .= params.beta_env
+    vmat = create_virus_matrix(params.beta_env, age_categories, nclasses)
 
     # Force matrix
-    vfmat = zeros(typeof(params.beta_force[1]), tm_size, tm_size)
-    bmat = @view vfmat[cat_idx[:, 2], cat_idx[:, 1]]
-    bmat[diagind(bmat)] .= params.beta_force
+    vfmat = create_virus_matrix(params.beta_force, age_categories, nclasses)
 
     # Virus growth and decay
-    v_growth = fill(0.0 * unit(params.virus_growth[1]), tm_size)
-    v_decay = fill(0.0 * unit(params.virus_growth[1]), tm_size)
-    v_growth[cat_idx[:, 3]] .= params.virus_growth
-    v_decay[cat_idx[:, 3]] .= params.virus_decay
+    v_growth, v_decay = create_virus_vector(params.virus_growth, params.virus_decay, age_categories, nclasses, 3)
+
   return EpiParams{typeof(unit(params.beta_force[1]))}(params.birth[1:end], v_growth, v_decay, tmat, vfmat, vmat)
 end
 
@@ -474,51 +446,22 @@ Function to create transition matrix from SEIRS parameters and return an `EpiPar
 function transition(params::SEIRSGrowth, age_categories = 1)
     # Set up number of classes etc
     nclasses = 5
-    cat_idx = reshape(1:(nclasses * age_categories), age_categories, nclasses)
 
-    # Set up transition matrix
-    tm_size = nclasses * age_categories
-    tmat = zeros(typeof(params.beta_force[1]), tm_size, tm_size)
+    from = [2, 3, 4]
+    to = [3, 4, 1]
+    paramDat = DataFrame(from = from, to = to, param = [params.mu, params.sigma, params.epsilon])
 
-    # Ageing
-    for i in 1:(nclasses-1)
-        amat = @view tmat[cat_idx[:, i], cat_idx[:, i]]
-        amat[diagind(amat, -1)].= params.ageing
-    end
-
-    # Death
-    for i in 1:(nclasses-1)
-        dmat = @view tmat[cat_idx[:, end], cat_idx[:, i]]
-        dmat[diagind(dmat)].= params.death[cat_idx[:, i]]
-    end
-
-    # Incubation
-    imat = @view tmat[cat_idx[:, 3], cat_idx[:, 2]]
-    imat[diagind(imat)] .= params.mu
-
-    # Recovery
-    rmat = @view tmat[cat_idx[:, 4], cat_idx[:, 3]]
-    rmat[diagind(rmat)] .= params.sigma
-
-    # Immunity waning
-    rmat = @view tmat[cat_idx[:, 1], cat_idx[:, 4]]
-    rmat[diagind(rmat)] .= params.epsilon
+    tmat = create_transition_matrix(params, paramDat, age_categories, nclasses)
 
     # Env virus matrix
-    vmat = zeros(typeof(params.beta_force[1]), tm_size, tm_size)
-    bmat = @view vmat[cat_idx[:, 2], cat_idx[:, 1]]
-    bmat[diagind(bmat)] .= params.beta_env
+    vmat = create_virus_matrix(params.beta_env, age_categories, nclasses)
 
     # Force matrix
-    vfmat = zeros(typeof(params.beta_force[1]), tm_size, tm_size)
-    bmat = @view vfmat[cat_idx[:, 2], cat_idx[:, 1]]
-    bmat[diagind(bmat)] .= params.beta_force
+    vfmat = create_virus_matrix(params.beta_force, age_categories, nclasses)
 
     # Virus growth and decay
-    v_growth = fill(0.0 * unit(params.virus_growth[1]), tm_size)
-    v_decay = fill(0.0 * unit(params.virus_growth[1]), tm_size)
-    v_growth[cat_idx[:, 3]] .= params.virus_growth
-    v_decay[cat_idx[:, 3]] .= params.virus_decay
+    v_growth, v_decay = create_virus_vector(params.virus_growth, params.virus_decay, age_categories, nclasses, 3)
+
   return EpiParams{typeof(unit(params.beta_force[1]))}(params.birth[1:end], v_growth, v_decay, tmat, vfmat, vmat)
 end
 
@@ -530,48 +473,24 @@ Function to create transition matrix from SEI2HRD parameters and return an `EpiP
 function transition(params::SEI2HRDGrowth, age_categories = 1)
     # Set up number of classes etc
     nclasses = 7
-    cat_idx = reshape(1:(nclasses * age_categories), age_categories, nclasses)
-
-    # Set up transition matrix
-    tm_size = nclasses * age_categories
-    tmat = zeros(typeof(params.beta_force[1]), tm_size, tm_size)
-
-    # Ageing
-    for i in 1:(nclasses-1)
-        amat = @view tmat[cat_idx[:, i], cat_idx[:, i]]
-        amat[diagind(amat, -1)].= params.ageing
-    end
-
-    # Death
-    for i in 1:(nclasses-1)
-        dmat = @view tmat[cat_idx[:, end], cat_idx[:, i]]
-        dmat[diagind(dmat)].= params.death[cat_idx[:, i]]
-    end
 
     ordered_transitions = (incubation_period = params.mu_1, symptoms_develop = params.mu_2, symptoms_worsen = params.hospitalisation, recovery_asymptomatic = params.sigma_1, recovery_symptomatic = params.sigma_2, recovery_hospital = params.sigma_hospital, death_symptomatic = params.death_home,
     death_hospitalised = params.death_hospital)
     from = [2, 3, 4, 3, 4, 5, 4, 5]
     to = [3, 4, 5, 6, 6, 6, 7, 7]
-    for i in eachindex(to)
-            view_mat = @view tmat[cat_idx[:, to[i]], cat_idx[:, from[i]]]
-            view_mat[diagind(view_mat)] .= ordered_transitions[i]
-    end
+    paramDat = DataFrame(from = from, to = to, param = ordered_transitions)
+
+    tmat = create_transition_matrix(params, paramDat, age_categories, nclasses)
 
     # Env virus matrix
-    vmat = zeros(typeof(params.beta_force[1]), tm_size, tm_size)
-    bmat = @view vmat[cat_idx[:, 2], cat_idx[:, 1]]
-    bmat[diagind(bmat)] .= params.beta_env
+    vmat = create_virus_matrix(params.beta_env, age_categories, nclasses)
 
     # Force matrix
-    vfmat = zeros(typeof(params.beta_force[1]), tm_size, tm_size)
-    bmat = @view vfmat[cat_idx[:, 2], cat_idx[:, 1]]
-    bmat[diagind(bmat)] .= params.beta_force
+    vfmat = create_virus_matrix(params.beta_force, age_categories, nclasses)
 
     # Virus growth and decay
-    v_growth = fill(0.0 * unit(params.virus_growth_asymp[1]), tm_size)
-    v_decay = fill(0.0 * unit(params.virus_growth_asymp[1]), tm_size)
-    v_growth[cat_idx[:, 3]] .= params.virus_growth_asymp
-    v_growth[cat_idx[:, 4]] .= params.virus_growth_symp
-    v_decay[cat_idx[:, 3]] .= params.virus_decay
+    v_growth, v_decay = create_virus_vector(params.virus_growth, params.virus_decay, age_categories, nclasses, 3)
+    v_growth .+= create_virus_vector(params.virus_growth, params.virus_decay, age_categories, nclasses, 4)[1]
+
   return EpiParams{typeof(unit(params.beta_force[1]))}(params.birth[1:end], v_growth, v_decay, tmat, vfmat, vmat)
 end

--- a/src/Epidemiology/EpiParams.jl
+++ b/src/Epidemiology/EpiParams.jl
@@ -9,22 +9,34 @@ Parameter set that houses information on birth and death rates of different clas
 mutable struct SIRGrowth{U <: Unitful.Units} <: AbstractParams
       birth::Matrix{TimeUnitType{U}}
       death::Matrix{TimeUnitType{U}}
+      ageing::Vector{TimeUnitType{U}}
       virus_growth::Vector{TimeUnitType{U}}
       virus_decay::Vector{TimeUnitType{U}}
       beta_force::Vector{TimeUnitType{U}}
       beta_env::Vector{TimeUnitType{U}}
       sigma::Vector{TimeUnitType{U}}
+
+    # Multiple age categories
     function SIRGrowth{U}(birth::Matrix{TimeUnitType{U}},
-        death::Matrix{TimeUnitType{U}}, virus_growth::Vector{TimeUnitType{U}}, virus_decay::Vector{TimeUnitType{U}}, beta_force::Vector{TimeUnitType{U}}, beta_env::Vector{TimeUnitType{U}}, sigma::Vector{TimeUnitType{U}}) where {U <: Unitful.Units}
-        size(birth) == size(death) || ("Birth and death vector lengths differ")
-        new{U}(birth, death, virus_growth, virus_decay, beta_force, beta_env, sigma)
+        death::Matrix{TimeUnitType{U}}, ageing::Vector{TimeUnitType{U}}, virus_growth::Vector{TimeUnitType{U}}, virus_decay::Vector{TimeUnitType{U}}, beta_force::Vector{TimeUnitType{U}}, beta_env::Vector{TimeUnitType{U}}, sigma::Vector{TimeUnitType{U}}) where {U <: Unitful.Units}
+
+        size(birth) == size(death) || error("Birth and death vector lengths differ")
+        all(beta_force .!= 0/day) & all(beta_env .!= 0/day) || warning("Transmission rates are zero.")
+        length(ageing) == (size(birth, 2) - 1) || error("Ageing parameters are not the correct length")
+
+        return new{U}(birth, death, ageing, virus_growth, virus_decay, beta_force, beta_env, sigma)
     end
+    # Single age category
     function SIRGrowth{U}(birth::Vector{TimeUnitType{U}},
         death::Vector{TimeUnitType{U}}, virus_growth::TimeUnitType{U}, virus_decay::TimeUnitType{U}, beta_force::TimeUnitType{U}, beta_env::TimeUnitType{U}, sigma::TimeUnitType{U}) where {U <: Unitful.Units}
-        length(birth) == length(death) || ("Birth and death vector lengths differ")
+
+        length(birth) == length(death) || error("Birth and death vector lengths differ")
+        (beta_force != 0/day) & (beta_env != 0/day) || warning("Transmission rate is zero.")
+
         new_birth = reshape(birth, length(birth), 1)
         new_death = reshape(birth, length(death), 1)
-        new{U}(new_birth, new_death, [virus_growth], [virus_decay], [beta_force], [beta_env], [sigma])
+        ageing = [0.0/day]
+        return new{U}(new_birth, new_death, ageing, [virus_growth], [virus_decay], [beta_force], [beta_env], [sigma])
     end
 end
 
@@ -36,22 +48,34 @@ Parameter set that houses information on birth and death rates of different clas
 mutable struct SISGrowth{U <: Unitful.Units} <: AbstractParams
       birth::Matrix{TimeUnitType{U}}
       death::Matrix{TimeUnitType{U}}
+      ageing::Vector{TimeUnitType{U}}
       virus_growth::Vector{TimeUnitType{U}}
       virus_decay::Vector{TimeUnitType{U}}
       beta_force::Vector{TimeUnitType{U}}
       beta_env::Vector{TimeUnitType{U}}
       sigma::Vector{TimeUnitType{U}}
+
+    # Multiple age categories
     function SISGrowth{U}(birth::Matrix{TimeUnitType{U}},
-        death::Matrix{TimeUnitType{U}}, virus_growth::Vector{TimeUnitType{U}}, virus_decay::Vector{TimeUnitType{U}}, beta_force::Vector{TimeUnitType{U}}, beta_env::Vector{TimeUnitType{U}}, sigma::Vector{TimeUnitType{U}}) where {U <: Unitful.Units}
-        size(birth) == size(death) || ("Birth and death vector lengths differ")
-        new{U}(birth, death, virus_growth, virus_decay, beta_force, beta_env, sigma)
+        death::Matrix{TimeUnitType{U}}, ageing::Vector{TimeUnitType{U}}, virus_growth::Vector{TimeUnitType{U}}, virus_decay::Vector{TimeUnitType{U}}, beta_force::Vector{TimeUnitType{U}}, beta_env::Vector{TimeUnitType{U}}, sigma::Vector{TimeUnitType{U}}) where {U <: Unitful.Units}
+
+        size(birth) == size(death) || error("Birth and death vector lengths differ")
+        all(beta_force .!= 0/day) & all(beta_env .!= 0/day) || warning("Transmission rates are zero.")
+        length(ageing) == (size(birth, 2) - 1) || error("Ageing parameters are not the correct length")
+
+        return new{U}(birth, death, ageing, virus_growth, virus_decay, beta_force, beta_env, sigma)
     end
+    # Single age category
     function SISGrowth{U}(birth::Vector{TimeUnitType{U}},
         death::Vector{TimeUnitType{U}}, virus_growth::TimeUnitType{U}, virus_decay::TimeUnitType{U}, beta_force::TimeUnitType{U}, beta_env::TimeUnitType{U}, sigma::TimeUnitType{U}) where {U <: Unitful.Units}
-        length(birth) == length(death) || ("Birth and death vector lengths differ")
+
+        length(birth) == length(death) || error("Birth and death vector lengths differ")
+        (beta_force != 0/day) & (beta_env != 0/day) || warning("Transmission rate is zero.")
+
         new_birth = reshape(birth, length(birth), 1)
         new_death = reshape(birth, length(death), 1)
-        new{U}(new_birth, new_death, [virus_growth], [virus_decay], [beta_force], [beta_env], [sigma])
+        ageing = [0.0/day]
+        return new{U}(new_birth, new_death, ageing, [virus_growth], [virus_decay], [beta_force], [beta_env], [sigma])
     end
 end
 
@@ -63,23 +87,36 @@ Parameter set that houses information on birth and death rates of different clas
 mutable struct SEIRGrowth{U <: Unitful.Units} <: AbstractParams
       birth::Matrix{TimeUnitType{U}}
       death::Matrix{TimeUnitType{U}}
+      ageing::Vector{TimeUnitType{U}}
       virus_growth::Vector{TimeUnitType{U}}
       virus_decay::Vector{TimeUnitType{U}}
       beta_force::Vector{TimeUnitType{U}}
       beta_env::Vector{TimeUnitType{U}}
       mu::Vector{TimeUnitType{U}}
       sigma::Vector{TimeUnitType{U}}
+
+    # Multiple age categories
     function SEIRGrowth{U}(birth::Matrix{TimeUnitType{U}},
-        death::Matrix{TimeUnitType{U}}, virus_growth::Vector{TimeUnitType{U}}, virus_decay::Vector{TimeUnitType{U}}, beta_force::Vector{TimeUnitType{U}}, beta_env::Vector{TimeUnitType{U}}, mu::Vector{TimeUnitType{U}}, sigma::Vector{TimeUnitType{U}}) where {U <: Unitful.Units}
-        size(birth) == size(death) || ("Birth and death vector lengths differ")
-        new{U}(birth, death, virus_growth, virus_decay, beta_force, beta_env, mu, sigma)
+        death::Matrix{TimeUnitType{U}},
+        ageing::Vector{TimeUnitType{U}},  virus_growth::Vector{TimeUnitType{U}}, virus_decay::Vector{TimeUnitType{U}}, beta_force::Vector{TimeUnitType{U}}, beta_env::Vector{TimeUnitType{U}}, mu::Vector{TimeUnitType{U}}, sigma::Vector{TimeUnitType{U}}) where {U <: Unitful.Units}
+
+        size(birth) == size(death) || error("Birth and death vector lengths differ")
+        all(beta_force .!= 0/day) & all(beta_env .!= 0/day) || warning("Transmission rates are zero.")
+        length(ageing) == (size(birth, 2) - 1) || error("Ageing parameters are not the correct length")
+
+        return new{U}(birth, death, ageing, virus_growth, virus_decay, beta_force, beta_env, mu, sigma)
     end
+    # Single age category
     function SEIRGrowth{U}(birth::Vector{TimeUnitType{U}},
         death::Vector{TimeUnitType{U}}, virus_growth::TimeUnitType{U}, virus_decay::TimeUnitType{U}, beta_force::TimeUnitType{U}, beta_env::TimeUnitType{U}, mu::TimeUnitType{U}, sigma::TimeUnitType{U}) where {U <: Unitful.Units}
-        length(birth) == length(death) || ("Birth and death vector lengths differ")
+
+        length(birth) == length(death) || error("Birth and death vector lengths differ")
+        (beta_force != 0/day) & (beta_env != 0/day) || warning("Transmission rate is zero.")
+
         new_birth = reshape(birth, length(birth), 1)
         new_death = reshape(birth, length(death), 1)
-        new{U}(new_birth, new_death, [virus_growth], [virus_decay], [beta_force], [beta_env], [mu], [sigma])
+        ageing = [0.0/day]
+        return new{U}(new_birth, new_death, ageing, [virus_growth], [virus_decay], [beta_force], [beta_env], [mu], [sigma])
     end
 end
 
@@ -91,6 +128,7 @@ Parameter set that houses information on birth and death rates of different clas
 mutable struct SEIRSGrowth{U <: Unitful.Units} <: AbstractParams
       birth::Matrix{TimeUnitType{U}}
       death::Matrix{TimeUnitType{U}}
+      ageing::Vector{TimeUnitType{U}}
       virus_growth::Vector{TimeUnitType{U}}
       virus_decay::Vector{TimeUnitType{U}}
       beta_force::Vector{TimeUnitType{U}}
@@ -98,17 +136,29 @@ mutable struct SEIRSGrowth{U <: Unitful.Units} <: AbstractParams
       mu::Vector{TimeUnitType{U}}
       sigma::Vector{TimeUnitType{U}}
       epsilon::Vector{TimeUnitType{U}}
+
+    # Multiple age categories
     function SEIRSGrowth{U}(birth::Matrix{TimeUnitType{U}},
-        death::Matrix{TimeUnitType{U}}, virus_growth::Vector{TimeUnitType{U}}, virus_decay::Vector{TimeUnitType{U}}, beta_force::Vector{TimeUnitType{U}}, beta_env::Vector{TimeUnitType{U}}, mu::Vector{TimeUnitType{U}}, sigma::Vector{TimeUnitType{U}}, epsilon::Vector{TimeUnitType{U}}) where {U <: Unitful.Units}
-        size(birth) == size(death) || ("Birth and death vector lengths differ")
-        new{U}(birth, death, virus_growth, virus_decay, beta_force, beta_env, mu, sigma, epsilon)
+        death::Matrix{TimeUnitType{U}},
+        ageing::Vector{TimeUnitType{U}}, virus_growth::Vector{TimeUnitType{U}}, virus_decay::Vector{TimeUnitType{U}}, beta_force::Vector{TimeUnitType{U}}, beta_env::Vector{TimeUnitType{U}}, mu::Vector{TimeUnitType{U}}, sigma::Vector{TimeUnitType{U}}, epsilon::Vector{TimeUnitType{U}}) where {U <: Unitful.Units}
+
+        size(birth) == size(death) || error("Birth and death vector lengths differ")
+        all(beta_force .!= 0/day) & all(beta_env .!= 0/day) || warning("Transmission rates are zero.")
+        length(ageing) == (size(birth, 2) - 1) || error("Ageing parameters are not the correct length")
+
+        return new{U}(birth, death, ageing, virus_growth, virus_decay, beta_force, beta_env, mu, sigma, epsilon)
     end
+    # Single age category
     function SEIRSGrowth{U}(birth::Vector{TimeUnitType{U}},
         death::Vector{TimeUnitType{U}}, virus_growth::TimeUnitType{U}, virus_decay::TimeUnitType{U}, beta_force::TimeUnitType{U}, beta_env::TimeUnitType{U}, mu::TimeUnitType{U}, sigma::TimeUnitType{U}, epsilon::TimeUnitType{U}) where {U <: Unitful.Units}
+
         length(birth) == length(death) || ("Birth and death vector lengths differ")
+        (beta_force != 0/day) & (beta_env != 0/day) || warning("Transmission rate is zero.")
+
         new_birth = reshape(birth, length(birth), 1)
         new_death = reshape(birth, length(death), 1)
-        new{U}(new_birth, new_death, [virus_growth], [virus_decay], [beta_force], [beta_env], [mu], [sigma], [epsilon])
+        ageing = [0.0/day]
+        return new{U}(new_birth, new_death, ageing, [virus_growth], [virus_decay], [beta_force], [beta_env], [mu], [sigma], [epsilon])
     end
 end
 
@@ -120,6 +170,7 @@ Parameter set that houses information on birth and death rates of different clas
 mutable struct SEI2HRDGrowth{U <: Unitful.Units} <: AbstractParams
       birth::Matrix{TimeUnitType{U}}
       death::Matrix{TimeUnitType{U}}
+      ageing::Vector{TimeUnitType{U}}
       virus_growth_asymp::Vector{TimeUnitType{U}}
       virus_growth_symp::Vector{TimeUnitType{U}}
       virus_decay::Vector{TimeUnitType{U}}
@@ -133,8 +184,11 @@ mutable struct SEI2HRDGrowth{U <: Unitful.Units} <: AbstractParams
       hospitalisation::Vector{TimeUnitType{U}}
       death_home::Vector{TimeUnitType{U}}
       death_hospital::Vector{TimeUnitType{U}}
+
+    # Multiple age categories
     function SEI2HRDGrowth{U}(birth::Matrix{TimeUnitType{U}},
-        death::Matrix{TimeUnitType{U}}, virus_growth_asymp::Vector{TimeUnitType{U}},
+        death::Matrix{TimeUnitType{U}},
+        ageing::Vector{TimeUnitType{U}}, virus_growth_asymp::Vector{TimeUnitType{U}},
         virus_growth_symp::Vector{TimeUnitType{U}}, virus_decay::Vector{TimeUnitType{U}}, beta_force::Vector{TimeUnitType{U}}, beta_env::Vector{TimeUnitType{U}}, sigma_1::Vector{TimeUnitType{U}},
         sigma_2::Vector{TimeUnitType{U}},
         sigma_hospital::Vector{TimeUnitType{U}},
@@ -143,10 +197,14 @@ mutable struct SEI2HRDGrowth{U <: Unitful.Units} <: AbstractParams
         hospitalisation::Vector{TimeUnitType{U}},
         death_home::Vector{TimeUnitType{U}},
         death_hospital::Vector{TimeUnitType{U}}) where {U <: Unitful.Units}
-        size(birth) == size(death) || ("Birth and death vector lengths differ")
+
+        size(birth) == size(death) || error("Birth and death vector lengths differ")
         all(beta_force .!= 0/day) & all(beta_env .!= 0/day) || warning("Transmission rates are zero.")
-        new{U}(birth, death, virus_growth_asymp, virus_growth_symp, virus_decay, beta_force, beta_env, mu, sigma)
+        length(ageing) == (size(birth, 2) - 1) || error("Ageing parameters are not the correct length")
+
+        return new{U}(birth, death, ageing, virus_growth_asymp, virus_growth_symp, virus_decay, beta_force, beta_env, mu, sigma)
     end
+    # Single age category
     function SEI2HRDGrowth{U}(birth::Vector{TimeUnitType{U}},
         death::Vector{TimeUnitType{U}}, virus_growth_asymp::TimeUnitType{U},
         virus_growth_symp::TimeUnitType{U}, virus_decay::TimeUnitType{U}, beta_force::TimeUnitType{U}, beta_env::TimeUnitType{U}, sigma_1::TimeUnitType{U},
@@ -157,11 +215,14 @@ mutable struct SEI2HRDGrowth{U <: Unitful.Units} <: AbstractParams
         hospitalisation::TimeUnitType{U},
         death_home::TimeUnitType{U},
         death_hospital::TimeUnitType{U}) where {U <: Unitful.Units}
+
         length(birth) == length(death) || ("Birth and death vector lengths differ")
         (beta_force != 0/day) & (beta_env != 0/day) || warning("Transmission rate is zero.")
+
         new_birth = reshape(birth, length(birth), 1)
         new_death = reshape(birth, length(death), 1)
-        new{U}(new_birth, new_death, [virus_growth_asymp], [virus_growth_symp], [virus_decay], [beta_force], [beta_env], [sigma_1], [sigma_2], [sigma_hospital], [mu_1], [mu_2], [hospitalisation], [death_home], [death_hospital])
+        ageing = [0.0/day]
+        return new{U}(new_birth, new_death, ageing, [virus_growth_asymp], [virus_growth_symp], [virus_decay], [beta_force], [beta_env], [sigma_1], [sigma_2], [sigma_hospital], [mu_1], [mu_2], [hospitalisation], [death_home], [death_hospital])
     end
 end
 
@@ -199,7 +260,8 @@ function SEI2HRDGrowth(birth::Vector{TimeUnitType{U}},
 end
 
 function SEI2HRDGrowth(birth::Matrix{TimeUnitType{U}},
-    death::Matrix{TimeUnitType{U}}, virus_growth_asymp::Vector{TimeUnitType{U}},
+    death::Matrix{TimeUnitType{U}},
+    ageing::Vector{TimeUnitType{U}},  virus_growth_asymp::Vector{TimeUnitType{U}},
     virus_growth_symp::Vector{TimeUnitType{U}},
     virus_decay::Vector{TimeUnitType{U}}, beta_force::Vector{TimeUnitType{U}}, beta_env::Vector{TimeUnitType{U}},
     prob_sym::Vector{Float64}, prob_hosp::Vector{Float64}, cfr_home::Vector{Float64}, cfr_hosp::Vector{Float64},
@@ -221,7 +283,7 @@ function SEI2HRDGrowth(birth::Matrix{TimeUnitType{U}},
     death_home = cfr_home .* 2/T_hosp
     # Hospital -> death
     death_hospital = cfr_hosp .* 1/T_hosp
-    return SEI2HRDGrowth{U}(birth, death, virus_growth_asymp, virus_growth_symp, beta_force, beta_env, sigma_1, sigma_2, sigma_hospital, mu_1, mu_2, hospitalisation, death_home, death_hospital)
+    return SEI2HRDGrowth{U}(birth, death, ageing,  virus_growth_asymp, virus_growth_symp, beta_force, beta_env, sigma_1, sigma_2, sigma_hospital, mu_1, mu_2, hospitalisation, death_home, death_hospital)
 end
 
 """
@@ -245,6 +307,17 @@ mutable struct EpiParams{U <: Unitful.Units} <: AbstractParams
     end
 end
 
+# function transition(paramDat::DataFrame, age_categories::Int64, nclasses::Int64)
+#     # Set up number of classes etc
+#     nclasses = 3
+#     cat_idx = reshape(1:(nclasses * age_categories), age_categories, nclasses)
+#
+#     # Set up transition matrix
+#     tm_size = nclasses * age_categories
+#     tmat = zeros(typeof(params.beta_force[1]), tm_size, tm_size)
+#
+#
+# end
 """
     transition(params::SISGrowth)
 
@@ -260,9 +333,10 @@ function transition(params::SISGrowth, age_categories = 1)
     tmat = zeros(typeof(params.beta_force[1]), tm_size, tm_size)
 
     # Ageing
-    age_diag = diagind(tmat, -1)
-    tmat[age_diag] .= 1/365days
-    tmat[age_diag[age_categories:age_categories:end]] .= 0.0/day
+    for i in 1:(nclasses-1)
+        amat = @view tmat[cat_idx[:, i], cat_idx[:, i]]
+        amat[diagind(amat, -1)].= params.ageing
+    end
 
     # Death
     for i in 1:(nclasses-1)
@@ -307,9 +381,10 @@ function transition(params::SIRGrowth, age_categories = 1)
     tmat = zeros(typeof(params.beta_force[1]), tm_size, tm_size)
 
     # Ageing
-    age_diag = diagind(tmat, -1)
-    tmat[age_diag] .= 1/365days
-    tmat[age_diag[age_categories:age_categories:end]] .= 0.0/day
+    for i in 1:(nclasses-1)
+        amat = @view tmat[cat_idx[:, i], cat_idx[:, i]]
+        amat[diagind(amat, -1)].= params.ageing
+    end
 
     # Death
     for i in 1:(nclasses-1)
@@ -354,9 +429,10 @@ function transition(params::SEIRGrowth, age_categories = 1)
     tmat = zeros(typeof(params.beta_force[1]), tm_size, tm_size)
 
     # Ageing
-    age_diag = diagind(tmat, -1)
-    tmat[age_diag] .= 1/365days
-    tmat[age_diag[age_categories:age_categories:end]] .= 0.0/day
+    for i in 1:(nclasses-1)
+        amat = @view tmat[cat_idx[:, i], cat_idx[:, i]]
+        amat[diagind(amat, -1)].= params.ageing
+    end
 
     # Death
     for i in 1:(nclasses-1)
@@ -405,9 +481,10 @@ function transition(params::SEIRSGrowth, age_categories = 1)
     tmat = zeros(typeof(params.beta_force[1]), tm_size, tm_size)
 
     # Ageing
-    age_diag = diagind(tmat, -1)
-    tmat[age_diag] .= 1/365days
-    tmat[age_diag[age_categories:age_categories:end]] .= 0.0/day
+    for i in 1:(nclasses-1)
+        amat = @view tmat[cat_idx[:, i], cat_idx[:, i]]
+        amat[diagind(amat, -1)].= params.ageing
+    end
 
     # Death
     for i in 1:(nclasses-1)
@@ -460,9 +537,10 @@ function transition(params::SEI2HRDGrowth, age_categories = 1)
     tmat = zeros(typeof(params.beta_force[1]), tm_size, tm_size)
 
     # Ageing
-    age_diag = diagind(tmat, -1)
-    tmat[age_diag] .= 1/365days
-    tmat[age_diag[age_categories:age_categories:end]] .= 0.0/day
+    for i in 1:(nclasses-1)
+        amat = @view tmat[cat_idx[:, i], cat_idx[:, i]]
+        amat[diagind(amat, -1)].= params.ageing
+    end
 
     # Death
     for i in 1:(nclasses-1)

--- a/test/canonical/test_SEI2HRD.jl
+++ b/test/canonical/test_SEI2HRD.jl
@@ -15,10 +15,8 @@ save_path = (@isdefined save_path) ? save_path : pwd()
 # Set simulation parameters
 birth = fill(0.0/day, 8)
 death = fill(0.0/day, 8)
-virus_growth = fill(0.0/day, 8)
-virus_growth[4:5] .= 1e-3/day
-virus_decay = fill(0.0/day, 8)
-virus_decay[4] = 1/3days
+virus_growth_asymp = virus_growth_symp = 1e-3/day
+virus_decay = 1/3days
 beta_force = 1e3/day
 beta_env = 1e3/day
 
@@ -39,7 +37,7 @@ T_hosp = 5days
 # Time to recovery if symptomatic
 T_rec = 11days
 
-param = SEI2HRDGrowth(birth, death, virus_growth, virus_decay, beta_force, beta_env, p_s, p_h, cfr_home, cfr_hosp, T_lat, T_asym, T_sym, T_hosp, T_rec)
+param = SEI2HRDGrowth(birth, death, virus_growth_asymp, virus_growth_symp, virus_decay, beta_force, beta_env, p_s, p_h, cfr_home, cfr_hosp, T_lat, T_asym, T_sym, T_hosp, T_rec)
 param = transition(param)
 
 # Set up simple gridded environment
@@ -92,10 +90,8 @@ times = 1year; interval = 1day; timestep = 1day
 
 birth = fill(0.0/day, 8)
 death = fill(0.0/day, 8)
-virus_growth = fill(0.0/day, 8)
-virus_growth[4:5] .= 1e-3/day
-virus_decay = fill(0.0/day, 8)
-virus_decay[4] = 1.0/day
+virus_growth_asymp = virus_growth_symp = 1e-3/day
+virus_decay = 1.0/day
 beta_force = 1e-10/day
 beta_env = 1e-10/day
 
@@ -116,7 +112,7 @@ T_hosp = 5days
 # Time to recovery if symptomatic
 T_rec = 11days
 
-param = SEI2HRDGrowth(birth, death, virus_growth, virus_decay, beta_force, beta_env, p_s, p_h, cfr_home, cfr_hosp, T_lat, T_asym, T_sym, T_hosp, T_rec)
+param = SEI2HRDGrowth(birth, death, virus_growth_asymp, virus_growth_symp, virus_decay, beta_force, beta_env, p_s, p_h, cfr_home, cfr_hosp, T_lat, T_asym, T_sym, T_hosp, T_rec)
 param = transition(param)
 
 # Set up simple gridded environment

--- a/test/canonical/test_SEI2HRD.jl
+++ b/test/canonical/test_SEI2HRD.jl
@@ -13,8 +13,9 @@ save_path = (@isdefined save_path) ? save_path : pwd()
 ## High transmission & 100% case fatality
 ##
 # Set simulation parameters
-birth = fill(0.0/day, 8)
-death = fill(0.0/day, 8)
+numclasses = 7
+birth = fill(0.0/day, numclasses)
+death = fill(0.0/day, numclasses)
 virus_growth_asymp = virus_growth_symp = 1e-3/day
 virus_decay = 1/3days
 beta_force = 1e3/day
@@ -57,14 +58,14 @@ dead = 0
 abun = [virus, susceptible, exposed, asymptomatic, symptomatic, hospitalised, recovered, dead]
 
 # Dispersal kernels for virus dispersal from different disease classes
-dispersal_dists = fill(1.0km, 8)
-dispersal_dists[4:5] .= 500.0km
+dispersal_dists = fill(1.0km, numclasses)
+dispersal_dists[3:4] .= 500.0km
 
 kernel = GaussianKernel.(dispersal_dists, 1e-10)
 movement = AlwaysMovement(kernel)
 
 # Traits for match to environment (turned off currently through param choice, i.e. virus matches environment perfectly)
-traits = GaussTrait(fill(298.0K, 8), fill(0.1K, 8))
+traits = GaussTrait(fill(298.0K, numclasses), fill(0.1K, numclasses))
 epilist = Simulation.SEI2HRD(traits, abun, movement, param)
 rel = Gauss{eltype(epienv.habitat)}()
 
@@ -88,8 +89,8 @@ times = 1year; interval = 1day; timestep = 1day
 ## Low transmission & 100% case fatality
 ##
 
-birth = fill(0.0/day, 8)
-death = fill(0.0/day, 8)
+birth = fill(0.0/day, numclasses)
+death = fill(0.0/day, numclasses)
 virus_growth_asymp = virus_growth_symp = 1e-3/day
 virus_decay = 1.0/day
 beta_force = 1e-10/day
@@ -132,14 +133,14 @@ dead = 0
 abun = [virus, susceptible, exposed, asymptomatic, symptomatic, hospitalised, recovered, dead]
 
 # Dispersal kernels for virus dispersal from different disease classes
-dispersal_dists = fill(1.0km, 8)
-dispersal_dists[4:5] .= 200.0km
+dispersal_dists = fill(1.0km, numclasses)
+dispersal_dists[3:4] .= 200.0km
 
 kernel = GaussianKernel.(dispersal_dists, 1e-10)
 movement = AlwaysMovement(kernel)
 
 # Traits for match to environment (turned off currently through param choice, i.e. virus matches environment perfectly)
-traits = GaussTrait(fill(298.0K, 8), fill(0.1K, 8))
+traits = GaussTrait(fill(298.0K, numclasses), fill(0.1K, numclasses))
 epilist = Simulation.SEI2HRD(traits, abun, movement, param)
 rel = Gauss{eltype(epienv.habitat)}()
 

--- a/test/canonical/test_SEIR.jl
+++ b/test/canonical/test_SEIR.jl
@@ -8,7 +8,7 @@ using Test
 do_save = (@isdefined do_save) ? do_save : false
 save_path = (@isdefined save_path) ? save_path : pwd()
 
-numclasses = 6
+numclasses = 5
 # Set simulation parameters
 birth = fill(0.0/day, numclasses)
 death = fill(0.0/day, numclasses)
@@ -37,7 +37,7 @@ abun = [virus, susceptible, exposed, infected, recovered, dead]
 
 # Dispersal kernels for virus and disease classes
 dispersal_dists = fill(100.0km, numclasses)
-dispersal_dists[4] = 700.0km
+dispersal_dists[3] = 700.0km
 kernel = GaussianKernel.(dispersal_dists, 1e-10)
 movement = AlwaysMovement(kernel)
 
@@ -51,10 +51,10 @@ epi = EpiSystem(epilist, epienv, rel)
 
 # Run simulation
 times = 2years; interval = 1day; timestep = 1day
-abuns = zeros(Int64, numclasses, grid[1]*grid[2], convert(Int64, floor(times / interval)) + 1)
+abuns = zeros(Int64, size(epi.abundances.matrix, 1), grid[1]*grid[2], convert(Int64, floor(times / interval)) + 1)
 @time simulate_record!(abuns, epi, times, interval, timestep; save=do_save, save_path=save_path)
 
 # Test no-one dies (death rate = 0)
 @test sum(abuns[end, :, :]) == 0
 # Test overall population size stays constant (birth rate = death rate = 0)
-@test all(sum(abuns[2:5, :, :], dims = (1, 2)) .== (susceptible + infected))
+@test all(sum(abuns[2:end, :, :], dims = (1, 2)) .== (susceptible + infected))

--- a/test/canonical/test_SEIRS.jl
+++ b/test/canonical/test_SEIRS.jl
@@ -8,7 +8,7 @@ using Test
 do_save = (@isdefined do_save) ? do_save : false
 save_path = (@isdefined save_path) ? save_path : pwd()
 
-numclasses = 6
+numclasses = 5
 # Set simulation parameters
 birth = fill(0.0/day, numclasses)
 death = fill(0.0/day, numclasses)
@@ -38,7 +38,7 @@ abun = [virus, susceptible, exposed, infected, recovered, dead]
 
 # Dispersal kernels for virus and disease classes
 dispersal_dists = fill(100.0km, numclasses)
-dispersal_dists[4] = 700.0km
+dispersal_dists[3] = 700.0km
 kernel = GaussianKernel.(dispersal_dists, 1e-10)
 movement = AlwaysMovement(kernel)
 
@@ -52,7 +52,7 @@ epi = EpiSystem(epilist, epienv, rel)
 
 # Run simulation
 times = 2years; interval = 1day; timestep = 1day
-abuns = zeros(Int64, numclasses, grid[1]*grid[2], convert(Int64, floor(times / interval)) + 1)
+abuns = zeros(Int64, size(epi.abundances.matrix, 1), grid[1]*grid[2], convert(Int64, floor(times / interval)) + 1)
 @time simulate_record!(abuns, epi, times, interval, timestep; save=do_save, save_path=save_path)
 
 # Test no-one dies (death rate = 0)

--- a/test/canonical/test_SIR.jl
+++ b/test/canonical/test_SIR.jl
@@ -9,7 +9,7 @@ do_save = (@isdefined do_save) ? do_save : false
 save_path = (@isdefined save_path) ? save_path : pwd()
 
 grid_sizes = [4, 8, 16]
-numclasses = 5
+numclasses = 4
 abuns = Vector{Array{Int64, 3}}(undef, length(grid_sizes))
 sumabuns = Vector{Array{Int64, 2}}(undef, length(grid_sizes))
 for i in eachindex(grid_sizes)
@@ -53,8 +53,7 @@ for i in eachindex(grid_sizes)
 
     # Run simulation
     times = 2years; interval = 1day; timestep = 1day
-    abuns[i] = zeros(Int64, numclasses, grid_sizes[i]^2,
-                     convert(Int64, floor(times / interval)) + 1)
+    abuns[i] = zeros(Int64, numclasses + 1, grid_sizes[i]^2, convert(Int64, floor(times / interval)) + 1)
     thisabun = abuns[i]
     @time simulate_record!(thisabun, epi, times, interval, timestep;
                            save=do_save, save_path=joinpath(save_path, "grid_size_$(grid_sizes[i])"))

--- a/test/canonical/test_SIR.jl
+++ b/test/canonical/test_SIR.jl
@@ -39,7 +39,7 @@ for i in eachindex(grid_sizes)
 
     # Dispersal kernels for virus and disease classes
     dispersal_dists = fill(100.0km, numclasses)
-    dispersal_dists[3] = 1_000.0km
+    dispersal_dists[2] = 1_000.0km
     kernel = GaussianKernel.(dispersal_dists, 1e-10)
     movement = AlwaysMovement(kernel)
 
@@ -53,7 +53,7 @@ for i in eachindex(grid_sizes)
 
     # Run simulation
     times = 2years; interval = 1day; timestep = 1day
-    abuns[i] = zeros(Int64, numclasses + 1, grid_sizes[i]^2, convert(Int64, floor(times / interval)) + 1)
+    abuns[i] = zeros(Int64, size(epi.abundances.matrix, 1), grid_sizes[i]^2, convert(Int64, floor(times / interval)) + 1)
     thisabun = abuns[i]
     @time simulate_record!(thisabun, epi, times, interval, timestep;
                            save=do_save, save_path=joinpath(save_path, "grid_size_$(grid_sizes[i])"))

--- a/test/canonical/test_SIS.jl
+++ b/test/canonical/test_SIS.jl
@@ -9,7 +9,7 @@ do_save = (@isdefined do_save) ? do_save : false
 save_path = (@isdefined save_path) ? save_path : pwd()
 
 grid_sizes = [4, 8, 16]
-numclasses = 4
+numclasses = 3
 abuns = Vector{Array{Int64, 3}}(undef, length(grid_sizes))
 sumabuns = Vector{Array{Int64, 2}}(undef, length(grid_sizes))
 for i in eachindex(grid_sizes)
@@ -38,7 +38,7 @@ for i in eachindex(grid_sizes)
 
     # Dispersal kernels for virus and disease classes
     dispersal_dists = fill(100.0km, numclasses)
-    dispersal_dists[3] = 1_000.0km
+    dispersal_dists[2] = 1_000.0km
     kernel = GaussianKernel.(dispersal_dists, 1e-10)
     movement = AlwaysMovement(kernel)
 
@@ -52,7 +52,7 @@ for i in eachindex(grid_sizes)
 
     # Run simulation
     times = 2years; interval = 1day; timestep = 1day
-    abuns[i] = zeros(Int64, numclasses, grid_sizes[i]^2,
+    abuns[i] = zeros(Int64, size(epi.abundances.matrix, 1), grid_sizes[i]^2,
                      convert(Int64, floor(times / interval)) + 1)
     thisabun = abuns[i]
     @time simulate_record!(thisabun, epi, times, interval, timestep; save=do_save, save_path=joinpath(save_path, "grid_size_$(grid_sizes[i])"))

--- a/test/canonical/test_SIS.jl
+++ b/test/canonical/test_SIS.jl
@@ -19,7 +19,7 @@ for i in eachindex(grid_sizes)
     beta_force = 1.0/day
     beta_env = 1.0/day
     sigma = 0.02/day
-    virus_growth = 1e-3/day
+    virus_growth = 1e-2/day
     virus_decay = 1.0/2day
     param = SISGrowth{typeof(unit(beta_force))}(birth, death, virus_growth, virus_decay, beta_force, beta_env, sigma)
     param = transition(param)

--- a/test/canonical/test_age.jl
+++ b/test/canonical/test_age.jl
@@ -17,10 +17,10 @@ for i in eachindex(age_cats)
     birth = fill(0.0/day, numclasses, age_cats[i])
     death = fill(0.0/day, numclasses, age_cats[i])
     ageing = fill(age_cats[i]/80years, age_cats[i] - 1)
-    beta_force = fill(0.1/day, age_cats[i])
-    beta_env = fill(0.1/day, age_cats[i])
+    beta_force = fill(1.0/day, age_cats[i])
+    beta_env = fill(1.0/day, age_cats[i])
     sigma = fill(0.02/day, age_cats[i])
-    virus_growth = fill(1e-3/day, age_cats[i])
+    virus_growth = fill(1e-2/day, age_cats[i])
     virus_decay = 1.0/2day
     if i == 1
         param = SISGrowth{typeof(unit(beta_force[1]))}(birth[1:end], death[1:end], virus_growth[1], virus_decay, beta_force[1], beta_env[1], sigma[1])

--- a/test/canonical/test_age.jl
+++ b/test/canonical/test_age.jl
@@ -1,0 +1,80 @@
+using Simulation
+using Unitful
+using Unitful.DefaultSymbols
+using Simulation.Units
+using Test
+
+# sort out settings to potentially save inputs/outputs of `simulate`
+do_save = (@isdefined do_save) ? do_save : false
+save_path = (@isdefined save_path) ? save_path : pwd()
+
+age_cats = [1, 2, 4]
+numclasses = 3
+abuns = Vector{Array{Int64, 3}}(undef, length(age_cats))
+sumabuns = Vector{Array{Int64, 2}}(undef, length(age_cats))
+for i in eachindex(age_cats)
+    # Set simulation parameters
+    birth = fill(0.0/day, numclasses, age_cats[i])
+    death = fill(0.0/day, numclasses, age_cats[i])
+    ageing = fill(age_cats[i]/80years, age_cats[i] - 1)
+    beta_force = fill(0.1/day, age_cats[i])
+    beta_env = fill(0.1/day, age_cats[i])
+    sigma = fill(0.02/day, age_cats[i])
+    virus_growth = fill(1e-3/day, age_cats[i])
+    virus_decay = 1.0/2day
+    if i == 1
+        param = SISGrowth{typeof(unit(beta_force[1]))}(birth[1:end], death[1:end], virus_growth[1], virus_decay, beta_force[1], beta_env[1], sigma[1])
+    else
+        param = SISGrowth{typeof(unit(beta_force[1]))}(birth, death, uconvert.(day^-1, ageing), virus_growth, virus_decay, beta_force, beta_env, sigma)
+    end
+    param = transition(param, age_cats[i])
+
+    # Set up simple gridded environment
+    grid = (4, 4)
+    area = 525_000.0km^2
+    epienv = simplehabitatAE(298.0K, grid, area, NoControl())
+
+    # Set initial population sizes for all categories: Virus, Susceptible, Infected, Recovered
+    virus = 0
+    susceptible = fill(Int64.(50_000_000/age_cats[i]), age_cats[i])
+    infected = fill(Int64.(10_000/age_cats[i]), age_cats[i])
+    dead = fill(0, age_cats[i])
+    abun = [virus; susceptible; infected; dead]
+
+    # Dispersal kernels for virus and disease classes
+    dispersal_dists = fill(100.0km, numclasses * age_cats[i])
+    cat_idx = reshape(1:(numclasses * age_cats[i]), age_cats[i], numclasses)
+    dispersal_dists[cat_idx[:, 2]] .= 1_000.0km
+    kernel = GaussianKernel.(dispersal_dists, 1e-10)
+    movement = AlwaysMovement(kernel)
+
+    # Traits for match to environment (turned off currently through param choice, i.e. virus matches environment perfectly)
+    traits = GaussTrait(fill(298.0K, numclasses * age_cats[i]), fill(0.1K, numclasses * age_cats[i]))
+    epilist = SIS(traits, abun, movement, param, age_cats[i])
+
+    # Create epi system with all information
+    rel = Gauss{eltype(epienv.habitat)}()
+    epi = EpiSystem(epilist, epienv, rel)
+
+    # Run simulation
+    times = 2years; interval = 1day; timestep = 1day
+    abuns[i] = zeros(Int64, numclasses * age_cats[i] + 1, 16, convert(Int64, floor(times / interval)) + 1)
+    thisabun = abuns[i]
+    @time simulate_record!(thisabun, epi, times, interval, timestep; save=do_save, save_path=joinpath(save_path, "age_cats_$(age_cats[i])"))
+
+    # Test no-one dies (death rate = 0)
+    @test sum(thisabun[end, :, :]) == 0
+    # Test overall population size stays constant (birth rate = death rate = 0)
+    @test all(sum(thisabun[2:(2 * age_cats[i] + 1), :, :], dims = (1, 2)) .== sum(susceptible + infected))
+    sumabuns[i] = sum(abuns[i], dims = 2)[:, 1, :]
+end
+
+# For each disease category, check trajectory is the same when we change grid size
+
+for j in 2:length(sumabuns)
+    for i in 2:numclasses
+        cat_idx1 = reshape(1:(numclasses * age_cats[j - 1]), age_cats[j - 1], numclasses) .+ 1
+        cat_idx2 = reshape(1:(numclasses * age_cats[j]), age_cats[j], numclasses) .+ 1
+        @test isapprox(sum(sumabuns[j-1][cat_idx1[:, i], :], dims = 1), sum(sumabuns[j][cat_idx2[:, i], :], dims = 1), rtol = 5e-2)
+    end
+end

--- a/test/test_EpiParams.jl
+++ b/test/test_EpiParams.jl
@@ -4,8 +4,8 @@ using Test
 using Simulation.Units
 import Simulation.SIRGrowth
 
-birth = [0.0/day; fill(1e-5/day, 3); 0.0/day]
-death = [0.0/day; fill(1e-5/day, 3); 0.0/day]
+birth = [fill(1e-5/day, 3); 0.0/day]
+death = [fill(1e-5/day, 3); 0.0/day]
 beta_force = 5.0/day
 beta_env = 0.5/day
 sigma = 0.05/day
@@ -14,11 +14,11 @@ virus_decay = 0.07/day
 @test_nowarn SIRGrowth{typeof(unit(beta_force))}(birth, death, virus_growth, virus_decay, beta_force, beta_env, sigma)
 param = SIRGrowth{typeof(unit(beta_force))}(birth, death, virus_growth, virus_decay, beta_force, beta_env, sigma)
 @test length(param.birth) == length(param.death)
-@test param.birth == birth
-@test param.death == death
-@test param.beta_force == beta_force
-@test param.beta_env == beta_env
-@test param.sigma == sigma
+@test param.birth[:, 1] == birth
+@test param.death[:, 1] == death
+@test param.beta_force[1] == beta_force
+@test param.beta_env[1] == beta_env
+@test param.sigma[1] == sigma
 
 transition_params = transition(param)
 @test size(transition_params.transition) == size(transition_params.transition_virus)


### PR DESCRIPTION
First pass at including age structure in the model. All original examples should run as they were, but now there is an optional flag for age categories when EpiList and transition matrices are created. Included a test for SIS model that runs different numbers of age categories and checks the summed results are the same each time.

Note: I have also reshuffled the code for creating transition matrices so that they only include the human categories - hence some changes to the update loops that may be relevant to ScottishCovidResponse/SCRCIssueTracking#148