### PR TITLE
Log spatial location for outputs

### DIFF
--- a/test/test_EpiEnv.jl
+++ b/test/test_EpiEnv.jl
@@ -72,10 +72,27 @@ end
     expected_matrix = fill(fillval, expected_grid)
 
     @testset "_shrink_to_active" begin
-        M = rand(grid...)
-        M_shrunk = Simulation._shrink_to_active(M, active)
-        @test size(M_shrunk) == expected_grid
-        @test M_shrunk == M[4:9, 2:9]
+        @testset "shrink a normal matrix" begin
+            M = rand(grid...)
+            M_shrunk = Simulation._shrink_to_active(M, active)
+            @test M_shrunk isa AxisArray
+            @test axisvalues(M_shrunk) == (4:9, 2:9)
+            @test size(M_shrunk) == expected_grid
+            @test M_shrunk == M[4:9, 2:9]
+        end
+        @testset "shrink an AxisArray matrix" begin
+            M = AxisArray(
+                rand(grid...);
+                x=Symbol.("x_", 1:grid[1]),
+                y=Symbol.("y_", 1:grid[2]),
+            )
+            M_shrunk = Simulation._shrink_to_active(M, active)
+            @test M_shrunk isa AxisArray
+            @test axisvalues(M_shrunk) == (Symbol.("x_", 4:9), Symbol.("y_", 2:9))
+            @test size(M_shrunk) == expected_grid
+            @test M_shrunk == M[4:9, 2:9]
+        end
+
     end
 
     @testset "Construct directly" begin
@@ -85,6 +102,7 @@ end
         @test size(epienv.habitat.matrix) == expected_grid
         @test epienv.habitat.size == expected_gridlength
         @test epienv.habitat.matrix == expected_matrix
+        @test epienv.initial_population isa AxisArray
     end
 
     @testset "Construct from initial population" begin
@@ -101,5 +119,6 @@ end
         @test epienv.habitat.size == expected_gridlength
         @test epienv.habitat.matrix == expected_matrix
         @test epienv.initial_population == expected_initial_pop
+        @test epienv.initial_population isa AxisArray
     end
 end

--- a/test/test_EpiEnv.jl
+++ b/test/test_EpiEnv.jl
@@ -108,17 +108,39 @@ end
     @testset "Construct from initial population" begin
         # Set an initial population of zeros
         # The zeros should not be masked out (but the NaNs should)
-        initial_pop = zeros(grid...)
-        initial_pop[.!active] .= NaN
+        @testset "Initial population is provided as a normal Matrix" begin
+            initial_pop = zeros(grid...)
+            initial_pop[.!active] .= NaN
 
-        epienv = simplehabitatAE(fillval, area, control, initial_pop)
-        expected_initial_pop = zeros(expected_grid)
+            epienv = simplehabitatAE(fillval, area, control, initial_pop)
+            expected_initial_pop = zeros(expected_grid)
 
-        @test epienv.active == expected_active
-        @test size(epienv.habitat.matrix) == expected_grid
-        @test epienv.habitat.size == expected_gridlength
-        @test epienv.habitat.matrix == expected_matrix
-        @test epienv.initial_population == expected_initial_pop
-        @test epienv.initial_population isa AxisArray
+            @test epienv.active == expected_active
+            @test size(epienv.habitat.matrix) == expected_grid
+            @test epienv.habitat.size == expected_gridlength
+            @test epienv.habitat.matrix == expected_matrix
+            @test epienv.initial_population == expected_initial_pop
+            @test epienv.initial_population isa AxisArray
+            @test axisvalues(epienv.initial_population) == (4:9, 2:9)
+        end
+        @testset "Initial population is provided as a AxisArray Matrix" begin
+            initial_pop = AxisArray(
+                zeros(grid...);
+                x=Symbol.("x_", 1:grid[1]),
+                y=Symbol.("y_", 1:grid[2]),
+            )
+            initial_pop.data[.!active] .= NaN
+
+            epienv = simplehabitatAE(fillval, area, control, initial_pop)
+            expected_initial_pop = zeros(expected_grid)
+            @test epienv.active == expected_active
+            @test size(epienv.habitat.matrix) == expected_grid
+            @test epienv.habitat.size == expected_gridlength
+            @test epienv.habitat.matrix == expected_matrix
+            @test epienv.initial_population == expected_initial_pop
+            @test axisvalues(epienv.initial_population) ==
+                (Symbol.("x_", 4:9), Symbol.("y_", 2:9))
+        end
+
     end
 end


### PR DESCRIPTION
To deal with the issue https://github.com/ScottishCovidResponse/SCRCIssueTracking/issues/271

- The spatial information is recorded through `epi.epienv.initial_population`, which is an AxisArray Matrix.
- The axes will be the selected subset (due to shrinking grid) of the original axes if `initial_population` is provided as an AxisArray. If `initial_population` is a normal matrix, the axes of the returned AxisArray are the selected coordinate index.