### PR TITLE
Add plot recipes for common plots

### DIFF
--- a/examples/Epidemiology/SEI2HRD_example.jl
+++ b/examples/Epidemiology/SEI2HRD_example.jl
@@ -65,7 +65,7 @@ epi = EpiSystem(epilist, epienv, rel)
 
 # Add in initial infections randomly (samples weighted by population size)
 N_cells = size(epi.abundances.matrix, 2)
-samp = sample(weights(1.0 .* human(epi.abundances)[1, :]), 100)
+samp = sample(1:N_cells, weights(1.0 .* human(epi.abundances)[1, :]), 100)
 virus(epi.abundances)[1, samp] .= 100 # Virus pop
 human(epi.abundances)[2, samp] .= 10 # Exposed pop
 

--- a/examples/Epidemiology/SEI2HRD_example.jl
+++ b/examples/Epidemiology/SEI2HRD_example.jl
@@ -61,9 +61,9 @@ epi = EpiSystem(epilist, epienv, rel)
 
 # Add in initial infections randomly (samples weighted by population size)
 N_cells = size(epi.abundances.matrix, 2)
-samp = sample(1:N_cells, weights(1.0 .* human(epi.abundances)[2, :]), 100)
-virus(epi.abundances)[1, samp] .= 100 # Virus pop
-human(epi.abundances)[4:5, samp] .= 10 # Inf pop
+samp = sample(1:N_cells, weights(1.0 .* Simulation.human(epi.abundances)[2, :]), 100)
+Simulation.virus(epi.abundances)[1, samp] .= 100 # Virus pop
+Simulation.human(epi.abundances)[4:5, samp] .= 10 # Inf pop
 
 # Run simulation
 abuns = zeros(Int64, 8, N_cells, 366)
@@ -72,7 +72,6 @@ times = 1year; interval = 1day; timestep = 1day
 
 if do_plot
     using Plots
-    plotlyjs()
     # View summed SIR dynamics for whole area
-    plot_epidynamics(epi, abuns)
+    display(plot_epidynamics(epi, abuns))
 end

--- a/examples/Epidemiology/SEI2HRD_example.jl
+++ b/examples/Epidemiology/SEI2HRD_example.jl
@@ -74,11 +74,5 @@ if do_plot
     using Plots
     plotlyjs()
     # View summed SIR dynamics for whole area
-    display(plot(mapslices(sum, abuns[2, :, :], dims = 1)[1, :], color = :Blue, label = "Susceptible"))
-    display(plot!(mapslices(sum, abuns[3, :, :], dims = 1)[1, :], color = :Orange, label = "Exposed"))
-    display(plot!(mapslices(sum, abuns[4, :, :], dims = 1)[1, :], color = :Yellow, label = "Asymptomatic"))
-    display(plot!(mapslices(sum, abuns[5, :, :], dims = 1)[1, :], color = :Red, label = "Symptomatic"))
-    display(plot!(mapslices(sum, abuns[6, :, :], dims = 1)[1, :], color = :Darkred, label = "Hospital"))
-    display(plot!(mapslices(sum, abuns[7, :, :], dims = 1)[1, :], color = :Green, label = "Recovered"))
-    display(plot!(mapslices(sum, abuns[8, :, :], dims = 1)[1, :], color = :Black, label = "Deaths"))
+    plot_epidynamics(epi, abuns)
 end

--- a/examples/Epidemiology/Scotland_run.jl
+++ b/examples/Epidemiology/Scotland_run.jl
@@ -82,7 +82,7 @@ end
 
 # Add in initial infections randomly (samples weighted by population size)
 N_cells = size(epi.abundances.matrix, 2)
-samp = sample(weights(1.0 .* epi.abundances.matrix[1, :]), 100)
+samp = sample(1:N_cells, weights(1.0 .* epi.abundances.matrix[1, :]), 100)
 epi.abundances.matrix[vcat(cat_idx[:, 2]...), samp] .= 10 # Exposed pop
 
 # Run simulation

--- a/examples/Epidemiology/Scotland_run.jl
+++ b/examples/Epidemiology/Scotland_run.jl
@@ -101,5 +101,5 @@ if do_plot
         "Recovered" => cat_idx[:, 6],
         "Deaths" => cat_idx[:, 7],
     )
-    plot_epidynamics(epi, abuns; category_map=category_map)
+    display(plot_epidynamics(epi, abuns; category_map=category_map))
 end

--- a/examples/Epidemiology/Scotland_run.jl
+++ b/examples/Epidemiology/Scotland_run.jl
@@ -88,15 +88,18 @@ abuns = zeros(Int64, size(epi.abundances.matrix, 1), N_cells, 366)
 times = 1year; interval = 1day; timestep = 1day
 @time simulate_record!(abuns, epi, times, interval, timestep)
 
+
 if do_plot
     using Plots
-    #plotlyjs()
     # View summed SIR dynamics for whole area
-    display(plot(mapslices(sum, abuns[cat_idx[:, 1], :, :], dims = (1, 2))[1, 1, :], color = :Blue, label = "Susceptible"))
-    display(plot!(mapslices(sum, abuns[cat_idx[:, 2], :, :], dims = (1, 2))[1, 1, :], color = :Orange, label = "Exposed"))
-    display(plot!(mapslices(sum, abuns[cat_idx[:, 3], :, :], dims = (1, 2))[1, 1, :], color = :Yellow, label = "Asymptomatic"))
-    display(plot!(mapslices(sum, abuns[cat_idx[:, 4], :, :], dims = (1, 2))[1, 1, :], color = :Red, label = "Symptomatic"))
-    display(plot!(mapslices(sum, abuns[cat_idx[:, 5], :, :], dims = (1, 2))[1, 1, :], color = :Darkred, label = "Hospital"))
-    display(plot!(mapslices(sum, abuns[cat_idx[:, 6], :, :], dims = (1, 2))[1, 1, :], color = :Green, label = "Recovered"))
-    display(plot!(mapslices(sum, abuns[cat_idx[:, 7], :, :], dims = (1, 2))[1, 1, :], color = :Black, label = "Deaths"))
+    category_map = (
+        "Susceptible" => cat_idx[:, 1],
+        "Exposed" => cat_idx[:, 2],
+        "Asymptomatic" => cat_idx[:, 3],
+        "Symptomatic" => cat_idx[:, 4],
+        "Hospital" => cat_idx[:, 5],
+        "Recovered" => cat_idx[:, 6],
+        "Deaths" => cat_idx[:, 7],
+    )
+    plot_epidynamics(epi, abuns; category_map=category_map)
 end

--- a/examples/Epidemiology/UK_run.jl
+++ b/examples/Epidemiology/UK_run.jl
@@ -90,13 +90,15 @@ times = 1year; interval = 1day; timestep = 1day
 
 if do_plot
     using Plots
-    #plotlyjs()
     # View summed SIR dynamics for whole area
-    display(plot(mapslices(sum, abuns[cat_idx[:, 1], :, :], dims = (1, 2))[1, 1, :], color = :Blue, label = "Susceptible"))
-    display(plot!(mapslices(sum, abuns[cat_idx[:, 2], :, :], dims = (1, 2))[1, 1, :], color = :Orange, label = "Exposed"))
-    display(plot!(mapslices(sum, abuns[cat_idx[:, 3], :, :], dims = (1, 2))[1, 1, :], color = :Yellow, label = "Asymptomatic"))
-    display(plot!(mapslices(sum, abuns[cat_idx[:, 4], :, :], dims = (1, 2))[1, 1, :], color = :Red, label = "Symptomatic"))
-    display(plot!(mapslices(sum, abuns[cat_idx[:, 5], :, :], dims = (1, 2))[1, 1, :], color = :Darkred, label = "Hospital"))
-    display(plot!(mapslices(sum, abuns[cat_idx[:, 6], :, :], dims = (1, 2))[1, 1, :], color = :Green, label = "Recovered"))
-    display(plot!(mapslices(sum, abuns[cat_idx[:, 7], :, :], dims = (1, 2))[1, 1, :], color = :Black, label = "Deaths"))
+    category_map = (
+        "Susceptible" => cat_idx[:, 1],
+        "Exposed" => cat_idx[:, 2],
+        "Asymptomatic" => cat_idx[:, 3],
+        "Symptomatic" => cat_idx[:, 4],
+        "Hospital" => cat_idx[:, 5],
+        "Recovered" => cat_idx[:, 6],
+        "Deaths" => cat_idx[:, 7],
+    )
+    plot_epidynamics(epi, abuns; category_map=category_map)
 end

--- a/examples/Epidemiology/UK_run.jl
+++ b/examples/Epidemiology/UK_run.jl
@@ -100,5 +100,5 @@ if do_plot
         "Recovered" => cat_idx[:, 6],
         "Deaths" => cat_idx[:, 7],
     )
-    plot_epidynamics(epi, abuns; category_map=category_map)
+    display(plot_epidynamics(epi, abuns; category_map=category_map))
 end

--- a/examples/Epidemiology/UK_run.jl
+++ b/examples/Epidemiology/UK_run.jl
@@ -82,7 +82,7 @@ end
 
 # Add in initial infections randomly (samples weighted by population size)
 N_cells = size(epi.abundances.matrix, 2)
-samp = sample(weights(1.0 .* epi.abundances.matrix[1, :]), 100)
+samp = sample(1:N_cells, weights(1.0 .* epi.abundances.matrix[1, :]), 100)
 epi.abundances.matrix[vcat(cat_idx[:, 2]...), samp] .= 10 # Exposed pop
 
 # Run simulation

--- a/src/Epidemiology/EpiPlots.jl
+++ b/src/Epidemiology/EpiPlots.jl
@@ -9,11 +9,6 @@ function _default_steps(abuns)
     return Int.(floor.(range(1, N_steps; length=4)))
 end
 
-function _default_clim(abuns, idx, steps)
-    max_val = maximum(maximum(abuns[idx, :, step]) for step in steps)
-    return (0, max_val)
-end
-
 """
     plot_epiheatmaps(
         abuns::AbstractArray{<:Integer, 3},

--- a/src/Epidemiology/EpiPlots.jl
+++ b/src/Epidemiology/EpiPlots.jl
@@ -80,6 +80,8 @@ end
             background_color_outside --> :white
             aspect_ratio --> 1
             grid --> false
+            xlims --> extrema(x)
+            ylims --> extrema(y)
             x, y, data
         end
         subplot += 1

--- a/src/Epidemiology/EpiPlots.jl
+++ b/src/Epidemiology/EpiPlots.jl
@@ -13,7 +13,7 @@ end
     plot_epiheatmaps(
         epi::AbstractEpiSystem,
         abuns::AbstractArray{<:Integer, 3};
-        compartment="Infected",
+        compartment="Exposed",
         steps=[],
     )
 
@@ -44,7 +44,7 @@ function _check_args(h)
 end
 @recipe function f(
     h::Plot_EpiHeatmaps;
-    compartment="Infected",
+    compartment="Exposed",
     steps=[],
 )
     _check_args(h)

--- a/src/Epidemiology/EpiPlots.jl
+++ b/src/Epidemiology/EpiPlots.jl
@@ -61,6 +61,7 @@ end
     # Transpose by default
     # `match_dimensions` is the same as `transpose`
     match_dimensions --> true
+    seriescolor --> :heat
 
     subplot = 1
     gridsize = size(epi.epienv.habitat.matrix)

--- a/src/Epidemiology/EpiPlots.jl
+++ b/src/Epidemiology/EpiPlots.jl
@@ -63,7 +63,7 @@ end
         data[.!epi.epienv.active] .= NaN
         @series begin
             seriestype := :heatmap
-            title := "Day $step ($compartment)"
+            title := "Step $step ($compartment)"
             subplot := subplot
             background_color --> :lightblue
             background_color_outside --> :white

--- a/src/Epidemiology/EpiPlots.jl
+++ b/src/Epidemiology/EpiPlots.jl
@@ -50,7 +50,6 @@ end
     if isempty(steps)
         steps = _default_steps(abuns)
     end
-    clim = _default_clim(abuns, idx, steps)
 
     layout := length(steps)
 
@@ -60,7 +59,6 @@ end
         data = reshape(abuns[idx, :, step], gridsize...)
         @series begin
             seriestype := :heatmap
-            clims := clim
             title := "Day $step ($compartment)"
             subplot := subplot
             data

--- a/src/Epidemiology/EpiPlots.jl
+++ b/src/Epidemiology/EpiPlots.jl
@@ -56,11 +56,16 @@ end
     subplot = 1
     gridsize = size(epienv.habitat.matrix)
     for step in steps
-        data = reshape(abuns[idx, :, step], gridsize...)
+        data = Float64.(reshape(abuns[idx, :, step], gridsize...))
+        data[.!epienv.active] .= NaN
         @series begin
             seriestype := :heatmap
             title := "Day $step ($compartment)"
             subplot := subplot
+            background_color --> :lightblue
+            background_color_outside --> :white
+            aspect_ratio --> 1
+            grid --> false
             data
         end
         subplot += 1

--- a/src/Epidemiology/EpiPlots.jl
+++ b/src/Epidemiology/EpiPlots.jl
@@ -15,7 +15,7 @@ function _default_clim(abuns, idx, steps)
 end
 
 """
-    epiheatmaps(
+    plot_epiheatmaps(
         abuns::AbstractArray{<:Integer, 3},
         epilist::EpiList,
         epienv::AbstractEpiEnv;
@@ -25,9 +25,9 @@ end
 
 Plot heatmaps of `abuns` for `compartment` at `steps`.
 """
-epiheatmaps
-@userplot EpiHeatmaps
-function _check_args(h::EpiHeatmaps)
+plot_epiheatmaps
+@userplot Plot_EpiHeatmaps
+function _check_args(h)
     correct_args = (
         length(h.args) == 3 &&
         isa(h.args[1], AbstractArray{<:Integer, 3}) &&
@@ -35,12 +35,12 @@ function _check_args(h::EpiHeatmaps)
     )
     if !correct_args
         throw(ArgumentError(
-            "epiheatmaps requires (abuns, EpiList, EpiEnv); got: $(typeof(h.args))"
+            "$(typeof(h)) requires (abuns, EpiList, EpiEnv); got: $(typeof(h.args))"
         ))
     end
 end
 @recipe function f(
-    h::EpiHeatmaps;
+    h::Plot_EpiHeatmaps;
     compartment="Infected",
     steps=[],
 )
@@ -64,5 +64,32 @@ end
             data
         end
         subplot += 1
+    end
+end
+
+"""
+    plot_epidynamics(
+        abuns::AbstractArray{<:Integer, 3},
+        epilist::EpiList,
+        epienv::AbstractEpiEnv,
+    )
+
+Plot the dynamics over time of `abuns`.
+"""
+plot_epidynamics
+@userplot Plot_EpiDynamics
+@recipe function f(h::Plot_EpiDynamics)
+    _check_args(h)
+    abuns, epilist, epienv = h.args
+
+    for (idx, name) in enumerate(epilist.names)
+        data = vec(mapslices(sum, abuns[idx, :, :], dims = 1))
+        title --> "Infection dynamics"
+        xguide --> "Step"
+        yguide --> "Totals"
+        @series begin
+            label := name
+            data
+        end
     end
 end

--- a/src/Epidemiology/EpiPlots.jl
+++ b/src/Epidemiology/EpiPlots.jl
@@ -52,7 +52,7 @@ end
 )
     _check_args(h)
     epi, abuns = h.args
-    idx = _compartment_idx(compartment, epi.epilist.names)
+    idx = _compartment_idx(compartment, epi.epilist.human.names)
     if isempty(steps)
         steps = _default_steps(abuns)
     end
@@ -122,7 +122,7 @@ plot_epidynamics
 
     if isnothing(category_map)
         # Make each compartment its own category
-        category_map = (name => [idx] for (idx, name) in enumerate(epi.epilist.names))
+        category_map = (name => [idx] for (idx, name) in enumerate(epi.epilist.human.names))
     end
 
     for (name, idx) in category_map

--- a/src/Epidemiology/EpiPlots.jl
+++ b/src/Epidemiology/EpiPlots.jl
@@ -89,11 +89,11 @@ Plot the dynamics of `abuns` summed over space, as a function of time.
 - `abuns`: The array of abundances to plot, of size Ncompartments x Ncells x Nsteps
 
 ## Keyword arguments
-- `category_map`: A list of key-value pairs where the keys are category names, and the
-    values are a list of compartment indices associated with that category. These compartments
-    will be summed in the plot. For example, the following will plot the sum of compartments 1
-    and 2 as the `Susceptible` category, and the sum of compartments 3 and 4 as the `Infected`
-    category.
+- `category_map`: An iterable of key-value pairs where the keys are category names, and the
+    values are a list of compartment indices associated with that category. These
+    compartments will be summed in the plot. For example, the following will plot the sum of
+    compartments 1 and 2 as the `Susceptible` category, and the sum of compartments 3 and 4
+    as the `Infected` category.
 
         category_map = ("Susceptible" => [1, 2], "Infected" => [3, 4])
 

--- a/src/Epidemiology/EpiPlots.jl
+++ b/src/Epidemiology/EpiPlots.jl
@@ -27,6 +27,9 @@ Plot heatmaps of `abuns` for `compartment` at `steps`.
 - `compartment`: The compartment to plot
 - `steps`: A list of steps to plot (one heatmap for each step). If empty, plots 4
     equally-spaced steps.
+
+!!! note
+    Heatmaps are transposed by default. Pass in `transpose=false` to turn this off.
 """
 plot_epiheatmaps
 @userplot Plot_EpiHeatmaps
@@ -55,12 +58,20 @@ end
     end
 
     layout := length(steps)
+    # Transpose by default
+    # `match_dimensions` is the same as `transpose`
+    match_dimensions --> true
 
     subplot = 1
     gridsize = size(epi.epienv.habitat.matrix)
     for step in steps
         data = Float64.(reshape(abuns[idx, :, step], gridsize...))
         data[.!epi.epienv.active] .= NaN
+        x = 1:size(data, 2)
+        y = 1:size(data, 1)
+        if plotattributes[:match_dimensions]
+            x, y = y, x
+        end
         @series begin
             seriestype := :heatmap
             title := "Step $step ($compartment)"
@@ -69,7 +80,7 @@ end
             background_color_outside --> :white
             aspect_ratio --> 1
             grid --> false
-            data
+            x, y, data
         end
         subplot += 1
     end

--- a/src/Epidemiology/EpiPlots.jl
+++ b/src/Epidemiology/EpiPlots.jl
@@ -1,0 +1,70 @@
+function _compartment_idx(compartment, names)
+    idx = findfirst(names .== compartment)
+    isnothing(idx) && throw(ArgumentError("Compartment $compartment not in $names"))
+    return idx
+end
+
+function _default_steps(abuns)
+    N_steps = size(abuns, 3)
+    return Int.(floor.(range(1, N_steps; length=4)))
+end
+
+function _default_clim(abuns, idx, steps)
+    max_val = maximum(maximum(abuns[idx, :, step]) for step in steps)
+    return (0, max_val)
+end
+
+"""
+    epiheatmaps(
+        abuns::AbstractArray{<:Integer, 3},
+        epilist::EpiList,
+        epienv::AbstractEpiEnv;
+        compartment="Infected",
+        steps=[],
+    )
+
+Plot heatmaps of `abuns` for `compartment` at `steps`.
+"""
+epiheatmaps
+@userplot EpiHeatmaps
+function _check_args(h::EpiHeatmaps)
+    correct_args = (
+        length(h.args) == 3 &&
+        isa(h.args[1], AbstractArray{<:Integer, 3}) &&
+        isa(h.args[2], EpiList) && isa(h.args[3], AbstractEpiEnv)
+    )
+    if !correct_args
+        throw(ArgumentError(
+            "epiheatmaps requires (abuns, EpiList, EpiEnv); got: $(typeof(h.args))"
+        ))
+    end
+end
+@recipe function f(
+    h::EpiHeatmaps;
+    compartment="Infected",
+    steps=[],
+)
+    _check_args(h)
+    abuns, epilist, epienv = h.args
+    idx = _compartment_idx(compartment, epilist.names)
+    if isempty(steps)
+        steps = _default_steps(abuns)
+    end
+    clim = _default_clim(abuns, idx, steps)
+
+    layout := length(steps)
+
+    subplot = 1
+    gridsize = size(epienv.habitat.matrix)
+    for step in steps
+        data = reshape(abuns[idx, :, step], gridsize...)
+        @series begin
+            seriestype := :heatmap
+            clims := clim
+            title := "Day $step ($compartment)"
+            subplot := subplot
+            data
+        end
+        subplot += 1
+    end
+end

--- a/src/Epidemiology/EpiSystem.jl
+++ b/src/Epidemiology/EpiSystem.jl
@@ -31,6 +31,8 @@ zeros(Float64, nrow(df)), zeros(Int64, nrow(df)))
     EpiSystem{EE <: AbstractEpiEnv, EL <: EpiList, ER <: AbstractRelationship} <: AbstractEpiSystem{EE, EL, ER}
 
 EpiSystem houses information on different disease classes, `epilist`, the environment, `epienv`, and their relationship to one another, `relationship`.
+
+See `help?>plot_epidynamics` and `help?>plot_epiheatmaps` for relevant plotting functions.
 """
 mutable struct EpiSystem{EE <: AbstractEpiEnv, EL <: EpiList, ER <: AbstractTraitRelationship} <: AbstractEpiSystem{EE, EL, ER}
   abundances::EpiLandscape

--- a/src/Simulation.jl
+++ b/src/Simulation.jl
@@ -148,6 +148,8 @@ export populate!
 include("Epidemiology/EpiHelper.jl")
 export simulate!, simulate_record!
 
+include("Epidemiology/EpiPlots.jl")
+
 # Path into package
 path(paths...) = joinpath(@__DIR__, "..", paths...)
 


### PR DESCRIPTION
Addresses https://github.com/ScottishCovidResponse/SCRCIssueTracking/issues/2

Adds two plot recipes, wrapping up the existing plots in the examples:
- `plot_epidynamics`: Plot the spatially-summed dynamics over time. This can take in a keyword argument indicating which compartments to consolidate.
- `plot_epiheatmaps`: Plots spatial heatmaps at several timesteps. Currently only works for a single specified compartment

We could improve/generalise the above once we figure out indexing issues (e.g.  https://github.com/ScottishCovidResponse/SCRCIssueTracking/issues/281)

Example usage:

### Plot dynamics for all the compartments
```julia
plot_epidynamics(epi, abuns)
```
![Screenshot 2020-05-28 at 12 45 54](https://user-images.githubusercontent.com/7861876/83138461-b94b6300-a0e2-11ea-83c4-da3e0c28b56a.png)

### Plot dynamics for custom categories
```julia
category_map = (
    "Susceptible" => cat_idx[:, 1],
    "Exposed" => cat_idx[:, 2],
    "Asymptomatic" => cat_idx[:, 3],
    "Symptomatic" => cat_idx[:, 4],
    "Hospital" => cat_idx[:, 5],
    "Recovered" => cat_idx[:, 6],
    "Deaths" => cat_idx[:, 7],
)
plot_epidynamics(epi, abuns; category_map=category_map)
```
![Screenshot 2020-05-28 at 12 49 05](https://user-images.githubusercontent.com/7861876/83138556-e0099980-a0e2-11ea-976b-291a83212a30.png)

### Plot heatmaps
```julia
plot_epiheatmaps(epi, abuns; compartment="Exposed", steps=[1, 7, 14, 21], clim=(0, 900))
```
![Screenshot 2020-05-29 at 12 02 33](https://user-images.githubusercontent.com/7861876/83253153-64702100-a1a4-11ea-8b33-92d57cf12aa2.png)
