### PR TITLE
Deterministic movement and other speed ups

### DIFF
--- a/examples/Epidemiology/SEI3HRD_example.jl
+++ b/examples/Epidemiology/SEI3HRD_example.jl
@@ -4,93 +4,97 @@ using Unitful.DefaultSymbols
 using Simulation.Units
 using Simulation.ClimatePref
 using StatsBase
+using Plots
 
-do_plot = false
+function run_model(times::Unitful.Time, interval::Unitful.Time, timestep::Unitful.Time, do_plot::Bool = false)
 
-numvirus = 1
-numclasses = 8
+    numvirus = 1
+    numclasses = 8
 
-# Set simulation parameters
-birth_rates = 1e-5/day; death_rates = birth_rates
-birth = fill(birth_rates, numclasses)
-death = fill(death_rates, numclasses)
-virus_growth_asymp = virus_growth_presymp = virus_growth_symp = 0.1/day
-virus_decay = 1.0/day
-beta_force = 10.0/day
-beta_env = 10.0/day
+    # Set simulation parameters
+    birth_rates = 1e-5/day; death_rates = birth_rates
+    birth = fill(birth_rates, numclasses)
+    death = fill(death_rates, numclasses)
+    virus_growth_asymp = virus_growth_presymp = virus_growth_symp = 0.1/day
+    virus_decay = 1.0/day
+    beta_force = 10.0/day
+    beta_env = 10.0/day
 
-# Prob of developing symptoms
-p_s = 0.96
-# Prob of hospitalisation
-p_h = 0.2
-# Case fatality ratio
-cfr_home = cfr_hospital = 0.1
-# Time exposed
-T_lat = 3days
-# Time asymptomatic
-T_asym = 5days
-# Time pre-symptomatic
-T_presym = 1.5days
-# Time symptomatic
-T_sym = 5days
-# Time in hospital
-T_hosp = 5days
-# Time to recovery if symptomatic
-T_rec = 11days
+    # Prob of developing symptoms
+    p_s = 0.96
+    # Prob of hospitalisation
+    p_h = 0.2
+    # Case fatality ratio
+    cfr_home = cfr_hospital = 0.1
+    # Time exposed
+    T_lat = 3days
+    # Time asymptomatic
+    T_asym = 5days
+    # Time pre-symptomatic
+    T_presym = 1.5days
+    # Time symptomatic
+    T_sym = 5days
+    # Time in hospital
+    T_hosp = 5days
+    # Time to recovery if symptomatic
+    T_rec = 11days
 
-param = SEI3HRDGrowth(birth, death, virus_growth_asymp, virus_growth_presymp, virus_growth_symp, virus_decay, beta_force, beta_env, p_s, p_h, cfr_home, cfr_hospital, T_lat, T_asym, T_presym, T_sym, T_hosp, T_rec)
-param = transition(param)
+    param = SEI3HRDGrowth(birth, death, virus_growth_asymp, virus_growth_presymp, virus_growth_symp, virus_decay, beta_force, beta_env, p_s, p_h, cfr_home, cfr_hospital, T_lat, T_asym, T_presym, T_sym, T_hosp, T_rec)
+    param = transition(param)
 
-# Read in population sizes for Scotland
-scotpop = Array{Float64, 2}(readfile(Simulation.path("test", "examples", "ScotlandDensity2011.tif"), 0.0, 7e5, 5e5, 1.25e6))
+    # Read in population sizes for Scotland
+    scotpop = Array{Float64, 2}(readfile(Simulation.path("test", "examples", "ScotlandDensity2011.tif"), 0.0, 7e5, 5e5, 1.25e6))
 
-# Set up simple gridded environment
-area = 525_000.0km^2
-epienv = simplehabitatAE(298.0K, area, NoControl(), scotpop)
+    # Set up simple gridded environment
+    area = 525_000.0km^2
+    epienv = simplehabitatAE(298.0K, area, NoControl(), scotpop)
 
-# Set population to initially have no individuals
-abun_h = (
-    Susceptible = 0,
-    Exposed = 0,
-    Asymptomatic = 0,
-    Presymptomatic = 0,
-    Symptomatic = 0,
-    Hospitalised = 0,
-    Recovered = 0,
-    Dead = 0
-)
-disease_classes = (
-    susceptible = ["Susceptible"],
-    infectious = ["Asymptomatic", "Presymptomatic", "Symptomatic"]
-)
-abun_v = (Virus = 0,)
+    # Set population to initially have no individuals
+    abun_h = (
+        Susceptible = 0,
+        Exposed = 0,
+        Asymptomatic = 0,
+        Presymptomatic = 0,
+        Symptomatic = 0,
+        Hospitalised = 0,
+        Recovered = 0,
+        Dead = 0
+    )
+    disease_classes = (
+        susceptible = ["Susceptible"],
+        infectious = ["Asymptomatic", "Presymptomatic", "Symptomatic"]
+    )
+    abun_v = (Virus = 0,)
 
-# Dispersal kernels for virus and disease classes
-dispersal_dists = fill(2.0km, numclasses)
-kernel = GaussianKernel.(dispersal_dists, 1e-10)
-movement = AlwaysMovement(kernel)
+    # Dispersal kernels for virus and disease classes
+    dispersal_dists = fill(2.0km, numclasses)
+    kernel = GaussianKernel.(dispersal_dists, 1e-10)
+    movement = AlwaysMovement(kernel)
 
-# Traits for match to environment (turned off currently through param choice, i.e. virus matches environment perfectly)
-traits = GaussTrait(fill(298.0K, numvirus), fill(0.1K, numvirus))
-epilist = EpiList(traits, abun_v, abun_h, disease_classes, movement, param)
-rel = Gauss{eltype(epienv.habitat)}()
+    # Traits for match to environment (turned off currently through param choice, i.e. virus matches environment perfectly)
+    traits = GaussTrait(fill(298.0K, numvirus), fill(0.1K, numvirus))
+    epilist = EpiList(traits, abun_v, abun_h, disease_classes, movement, param)
+    rel = Gauss{eltype(epienv.habitat)}()
 
-# Create epi system with all information
-epi = EpiSystem(epilist, epienv, rel)
+    # Create epi system with all information
+    epi = EpiSystem(epilist, epienv, rel)
 
-# Add in initial infections randomly (samples weighted by population size)
-N_cells = size(epi.abundances.matrix, 2)
-samp = sample(1:N_cells, weights(1.0 .* human(epi.abundances)[1, :]), 100)
-virus(epi.abundances)[1, samp] .= 100 # Virus pop
-human(epi.abundances)[2, samp] .= 10 # Exposed pop
+    # Add in initial infections randomly (samples weighted by population size)
+    N_cells = size(epi.abundances.matrix, 2)
+    samp = sample(1:N_cells, weights(1.0 .* human(epi.abundances)[1, :]), 100)
+    virus(epi.abundances)[1, samp] .= 100 # Virus pop
+    human(epi.abundances)[2, samp] .= 10 # Exposed pop
 
-# Run simulation
-abuns = zeros(Int64, numclasses, N_cells, 366)
-times = 2months; interval = 1day; timestep = 1day
-@time simulate_record!(abuns, epi, times, interval, timestep)
+    # Run simulation
+    abuns = zeros(Int64, numclasses, N_cells, 366)
+    times = 2months; interval = 1day; timestep = 1day
+    @time simulate_record!(abuns, epi, times, interval, timestep)
 
-if do_plot
-    using Plots
-    # View summed SIR dynamics for whole area
-    display(plot_epidynamics(epi, abuns))
+    if do_plot
+        # View summed SIR dynamics for whole area
+        display(plot_epidynamics(epi, abuns))
+    end
 end
+
+times = 1year; interval = 1day; timestep = 1day
+abuns = run_model(times, interval, timestep);

--- a/examples/Epidemiology/Scotland_run.jl
+++ b/examples/Epidemiology/Scotland_run.jl
@@ -95,7 +95,6 @@ function run_model(times::Unitful.Time, interval::Unitful.Time, timestep::Unitfu
 
     abun_v = (Environment = 0, Force = 0)
 
-
     # Dispersal kernels for virus and disease classes
     dispersal_dists = fill(1.0km, numclasses * age_categories)
     thresholds = fill(1e-3, numclasses * age_categories)
@@ -142,9 +141,9 @@ function run_model(times::Unitful.Time, interval::Unitful.Time, timestep::Unitfu
     end
 
     # Run simulation
-    abuns = zeros(Int64, size(epi.abundances.matrix, 1), N_cells,
+    abuns = zeros(UInt16, size(epi.abundances.matrix, 1), N_cells,
                   floor(Int, times/timestep) + 1)
-    @time simulate_record!(abuns, epi, times, interval, timestep, save, savepath)
+    @time simulate_record!(abuns, epi, times, interval, timestep, save = save, save_path = savepath)
 
     if do_plot
         # View summed SIR dynamics for whole area
@@ -164,5 +163,5 @@ function run_model(times::Unitful.Time, interval::Unitful.Time, timestep::Unitfu
     return abuns
 end
 
-times = 1year; interval = 1day; timestep = 1day
+times = 2months; interval = 1day; timestep = 1day
 abuns = run_model(times, interval, timestep);

--- a/examples/Epidemiology/Scotland_run.jl
+++ b/examples/Epidemiology/Scotland_run.jl
@@ -8,13 +8,19 @@ using Distributions
 using AxisArrays
 using HTTP
 using Plots
+using Profile
 
-function run_model(times::Unitful.Time, interval::Unitful.Time, timestep::Unitful.Time, do_plot::Bool = false)
+function run_model(times::Unitful.Time, interval::Unitful.Time, timestep::Unitful.Time, do_plot::Bool = false, do_download::Bool = true)
     # Download and read in population sizes for Scotland
-    file, io = mktemp()
-    r = HTTP.request("GET", "https://raw.githubusercontent.com/ScottishCovidResponse/temporary_data/master/human/demographics/scotland/data/demographics.h5")
-    write(io, r.body)
-    close(io)
+    dir = Simulation.path("test", "TEMP")
+    file = joinpath(dir, "demographics.h5")
+    if do_download
+        mkdir(Simulation.path("test", "TEMP"))
+        io = open(Simulation.path("test", "TEMP", "demographics.h5"), "w")
+        r = HTTP.request("GET", "https://raw.githubusercontent.com/ScottishCovidResponse/temporary_data/master/human/demographics/scotland/data/demographics.h5")
+        write(io, r.body)
+        close(io)
+    end
     scotpop = parse_hdf5(file, grid = "1km", component = "grid1km/10year/persons")
 
     # Read number of age categories
@@ -154,5 +160,5 @@ function run_model(times::Unitful.Time, interval::Unitful.Time, timestep::Unitfu
     return abuns
 end
 
-times = 1year; interval = 1day; timestep = 1day
-abuns = run_model(times, interval, timestep);
+times = 1month; interval = 1day; timestep = 1day
+abunl(times, interval, timestep);

--- a/examples/Epidemiology/Scotland_run.jl
+++ b/examples/Epidemiology/Scotland_run.jl
@@ -7,149 +7,152 @@ using StatsBase
 using Distributions
 using AxisArrays
 using HTTP
+using Plots
 
-do_plot = false
+function run_model(times::Unitful.Time, interval::Unitful.Time, timestep::Unitful.Time, do_plot::Bool = false)
+    # Download and read in population sizes for Scotland
+    file, io = mktemp()
+    r = HTTP.request("GET", "https://raw.githubusercontent.com/ScottishCovidResponse/temporary_data/master/human/demographics/scotland/data/demographics.h5")
+    write(io, r.body)
+    close(io)
+    scotpop = parse_hdf5(file, grid = "1km", component = "grid1km/10year/persons")
 
-# Download and read in population sizes for Scotland
-file, io = mktemp()
-r = HTTP.request("GET", "https://raw.githubusercontent.com/ScottishCovidResponse/temporary_data/master/human/demographics/scotland/data/demographics.h5")
-write(io, r.body)
-close(io)
-scotpop = parse_hdf5(file, grid = "1km", component = "grid1km/10year/persons")
+    # Read number of age categories
+    age_categories = size(scotpop, 3)
 
-# Read number of age categories
-age_categories = size(scotpop, 3)
+    # Set up simple gridded environment
+    area = (AxisArrays.axes(scotpop, 1)[end] + AxisArrays.axes(scotpop, 1)[2] -
+        2 * AxisArrays.axes(scotpop, 1)[1]) *
+        (AxisArrays.axes(scotpop, 2)[end] + AxisArrays.axes(scotpop, 2)[2] -
+        2 * AxisArrays.axes(scotpop, 2)[1]) * 1.0
 
-# Set up simple gridded environment
-area = (AxisArrays.axes(scotpop, 1)[end] + AxisArrays.axes(scotpop, 1)[2] -
-    2 * AxisArrays.axes(scotpop, 1)[1]) *
-    (AxisArrays.axes(scotpop, 2)[end] + AxisArrays.axes(scotpop, 2)[2] -
-    2 * AxisArrays.axes(scotpop, 2)[1]) * 1.0
+    # Sum up age categories and turn into simple matrix
+    total_pop = dropdims(sum(Float64.(scotpop), dims=3), dims=3)
+    total_pop = AxisArray(total_pop, AxisArrays.axes(scotpop)[1], AxisArrays.axes(scotpop)[2])
+    total_pop.data[total_pop .≈ 0.0] .= NaN
 
-# Sum up age categories and turn into simple matrix
-total_pop = dropdims(sum(Float64.(scotpop), dims=3), dims=3)
-total_pop = AxisArray(total_pop, AxisArrays.axes(scotpop)[1], AxisArrays.axes(scotpop)[2])
-total_pop.data[total_pop .≈ 0.0] .= NaN
+    # Set simulation parameters
+    numclasses = 8
+    numvirus = 1
+    birth_rates = fill(0.0/day, numclasses, age_categories)
+    death_rates = fill(0.0/day, numclasses, age_categories)
+    birth_rates[:, 2:4] .= uconvert(day^-1, 1/20years)
+    death_rates[1:end-1, :] .= uconvert(day^-1, 1/100years)
+    virus_growth_asymp = virus_growth_presymp = virus_growth_symp = fill(0.1/day, age_categories)
+    virus_decay = 1.0/day
+    beta_force = fill(10.0/day, age_categories)
+    beta_env = fill(10.0/day, age_categories)
+    ageing = fill(0.0/day, age_categories - 1) # no ageing for now
 
-# Set simulation parameters
-numclasses = 8
-numvirus = 1
-birth_rates = fill(0.0/day, numclasses, age_categories)
-death_rates = fill(0.0/day, numclasses, age_categories)
-birth_rates[:, 2:4] .= uconvert(day^-1, 1/20years)
-death_rates[1:end-1, :] .= uconvert(day^-1, 1/100years)
-virus_growth_asymp = virus_growth_presymp = virus_growth_symp = fill(0.1/day, age_categories)
-virus_decay = 1.0/day
-beta_force = fill(10.0/day, age_categories)
-beta_env = fill(10.0/day, age_categories)
-ageing = fill(0.0/day, age_categories - 1) # no ageing for now
+    # Prob of developing symptoms
+    p_s = fill(0.96, age_categories)
+    # Prob of hospitalisation
+    p_h = [0.143, 0.143, 0.1141, 0.117, 0.102, 0.125, 0.2, 0.303, 0.303, 0.303]
+    # Case fatality ratio
+    cfr_home = cfr_hospital = [0.0, 0.002, 0.002, 0.002, 0.004, 0.013, 0.036, 0.08, 0.148, 0.148]
+    # Time exposed
+    T_lat = 3days
+    # Time asymptomatic
+    T_asym = 5days
+    # Time pre-symptomatic
+    T_presym = 1.5days
+    # Time symptomatic
+    T_sym = 5days
+    # Time in hospital
+    T_hosp = 5days
+    # Time to recovery if symptomatic
+    T_rec = 11days
 
-# Prob of developing symptoms
-p_s = fill(0.96, age_categories)
-# Prob of hospitalisation
-p_h = fill(0.2, age_categories)
-# Case fatality ratio
-cfr_home = cfr_hospital = fill(0.1, age_categories)
-# Time exposed
-T_lat = 3days
-# Time asymptomatic
-T_asym = 5days
-# Time pre-symptomatic
-T_presym = 1.5days
-# Time symptomatic
-T_sym = 5days
-# Time in hospital
-T_hosp = 5days
-# Time to recovery if symptomatic
-T_rec = 11days
+    param = SEI3HRDGrowth(birth_rates, death_rates, ageing,
+                          virus_growth_asymp, virus_growth_presymp, virus_growth_symp, virus_decay,
+                          beta_force, beta_env, p_s, p_h, cfr_home, cfr_hospital,
+                          T_lat, T_asym, T_presym, T_sym, T_hosp, T_rec)
+    param = transition(param, age_categories)
 
-param = SEI3HRDGrowth(birth_rates, death_rates, ageing,
-                      virus_growth_asymp, virus_growth_presymp, virus_growth_symp, virus_decay,
-                      beta_force, beta_env, p_s, p_h, cfr_home, cfr_hospital,
-                      T_lat, T_asym, T_presym, T_sym, T_hosp, T_rec)
-param = transition(param, age_categories)
+    epienv = simplehabitatAE(298.0K, area, NoControl(), total_pop)
 
-epienv = simplehabitatAE(298.0K, area, NoControl(), total_pop)
-
-# Set population to initially have no individuals
-abun_h = (
-    Susceptible = fill(0, age_categories),
-    Exposed = fill(0, age_categories),
-    Asymptomatic = fill(0, age_categories),
-    Presymptomatic = fill(0, age_categories),
-    Symptomatic = fill(0, age_categories),
-    Hospitalised = fill(0, age_categories),
-    Recovered = fill(0, age_categories),
-    Dead = fill(0, age_categories)
-)
-
-disease_classes = (
-    susceptible = ["Susceptible"],
-    infectious = ["Asymptomatic", "Presymptomatic", "Symptomatic"]
-)
-
-abun_v = (Virus = 0,)
-
-# Dispersal kernels for virus and disease classes
-dispersal_dists = fill(1.0km, numclasses * age_categories)
-thresholds = fill(1e-3, numclasses * age_categories)
-cat_idx = reshape(1:(numclasses * age_categories), age_categories, numclasses)
-dispersal_dists[vcat(cat_idx[:, 3:5]...)] .= 20.0km
-thresholds[vcat(cat_idx[:, 3:5]...)] .= 1e-4
-kernel = GaussianKernel.(dispersal_dists, thresholds)
-movement = AlwaysMovement(kernel)
-
-# Traits for match to environment (turned off currently through param choice, i.e. virus matches environment perfectly)
-traits = GaussTrait(fill(298.0K, numvirus), fill(0.1K, numvirus))
-epilist = EpiList(traits, abun_v, abun_h, disease_classes,
-                  movement, param, age_categories)
-rel = Gauss{eltype(epienv.habitat)}()
-
-# Create epi system with all information
-epi = EpiSystem(epilist, epienv, rel)
-
-# Populate susceptibles according to actual population spread
-reshaped_pop =
-    reshape(scotpop[1:size(epienv.active, 1), 1:size(epienv.active, 2), :],
-            size(epienv.active, 1) * size(epienv.active, 2), size(scotpop, 3))'
-epi.abundances.matrix[cat_idx[:, 1], :] = reshaped_pop
-
-# Add in initial infections randomly (samples weighted by population size)
-# Define generator for all pair age x cell
-age_and_cells = Iterators.product(1:age_categories,
-                                  1:size(epi.abundances.matrix, 2))
-# Take all susceptibles of each age per cell
-pop_weights = epi.abundances.matrix[vcat(cat_idx[:, 1]...), :]
-# It would be nice if it wasn't necessary to call collect here
-N_cells = size(epi.abundances.matrix, 2)
-samp = sample(collect(age_and_cells), weights(1.0 .* vec(pop_weights)), 100)
-age_ids = getfield.(samp, 1)
-cell_ids = getfield.(samp, 2)
-# Add to exposed
-epi.abundances.matrix[vcat(cat_idx[age_ids, 2]...), cell_ids] .= 1
-# Remove from susceptible
-epi.abundances.matrix[vcat(cat_idx[age_ids, 1]...), cell_ids] =
-    epi.abundances.matrix[vcat(cat_idx[age_ids, 1]...), cell_ids] .- 1
-
-# Run simulation
-times = 2months; interval = 1day; timestep = 1day
-abuns = zeros(Int64, size(epi.abundances.matrix, 1), N_cells,
-              floor(Int, times/timestep) + 1)
-@time simulate_record!(abuns, epi, times, interval, timestep)
-
-if do_plot
-    using Plots
-    # View summed SIR dynamics for whole area
-    category_map = (
-        "Susceptible" => cat_idx[:, 1],
-        "Exposed" => cat_idx[:, 2],
-        "Asymptomatic" => cat_idx[:, 3],
-        "Presymptomatic" => cat_idx[:, 4],
-        "Symptomatic" => cat_idx[:, 5],
-        "Hospital" => cat_idx[:, 6],
-        "Recovered" => cat_idx[:, 7],
-        "Deaths" => cat_idx[:, 8],
+    # Set population to initially have no individuals
+    abun_h = (
+        Susceptible = fill(0, age_categories),
+        Exposed = fill(0, age_categories),
+        Asymptomatic = fill(0, age_categories),
+        Presymptomatic = fill(0, age_categories),
+        Symptomatic = fill(0, age_categories),
+        Hospitalised = fill(0, age_categories),
+        Recovered = fill(0, age_categories),
+        Dead = fill(0, age_categories)
     )
-    display(plot_epidynamics(epi, abuns, category_map = category_map))
-    display(plot_epiheatmaps(epi, abuns, steps = [21]))
+
+    disease_classes = (
+        susceptible = ["Susceptible"],
+        infectious = ["Asymptomatic", "Presymptomatic", "Symptomatic"]
+    )
+
+    abun_v = (Virus = 0,)
+
+    # Dispersal kernels for virus and disease classes
+    dispersal_dists = fill(1.0km, numclasses * age_categories)
+    thresholds = fill(1e-3, numclasses * age_categories)
+    cat_idx = reshape(1:(numclasses * age_categories), age_categories, numclasses)
+    dispersal_dists[vcat(cat_idx[:, 3:5]...)] .= 10.0km
+    thresholds[vcat(cat_idx[:, 3:5]...)] .= 1e-4
+    kernel = GaussianKernel.(dispersal_dists, thresholds)
+    movement = AlwaysMovement(kernel)
+
+    # Traits for match to environment (turned off currently through param choice, i.e. virus matches environment perfectly)
+    traits = GaussTrait(fill(298.0K, numvirus), fill(0.1K, numvirus))
+    epilist = EpiList(traits, abun_v, abun_h, disease_classes,
+                      movement, param, age_categories)
+    rel = Gauss{eltype(epienv.habitat)}()
+
+    # Create epi system with all information
+    epi = EpiSystem(epilist, epienv, rel)
+
+    # Populate susceptibles according to actual population spread
+    reshaped_pop =
+        reshape(scotpop[1:size(epienv.active, 1), 1:size(epienv.active, 2), :],
+                size(epienv.active, 1) * size(epienv.active, 2), size(scotpop, 3))'
+    epi.abundances.matrix[cat_idx[:, 1], :] = reshaped_pop
+
+    # Add in initial infections randomly (samples weighted by population size)
+    # Define generator for all pair age x cell
+    age_and_cells = Iterators.product(1:age_categories,
+                                      1:size(epi.abundances.matrix, 2))
+    # Take all susceptibles of each age per cell
+    pop_weights = epi.abundances.matrix[vcat(cat_idx[:, 1]...), :]
+    # It would be nice if it wasn't necessary to call collect here
+    N_cells = size(epi.abundances.matrix, 2)
+    samp = sample(collect(age_and_cells), weights(1.0 .* vec(pop_weights)), 100)
+    age_ids = getfield.(samp, 1)
+    cell_ids = getfield.(samp, 2)
+    # Add to exposed
+    epi.abundances.matrix[vcat(cat_idx[age_ids, 2]...), cell_ids] .= 1
+    # Remove from susceptible
+    epi.abundances.matrix[vcat(cat_idx[age_ids, 1]...), cell_ids] =
+        epi.abundances.matrix[vcat(cat_idx[age_ids, 1]...), cell_ids] .- 1
+    epi.abundances.matrix[epi.abundances.matrix .< 0] .= 0
+    # Run simulation
+    abuns = zeros(Int64, size(epi.abundances.matrix, 1), N_cells,
+                  floor(Int, times/timestep) + 1)
+    @time simulate_record!(abuns, epi, times, interval, timestep)
+
+    if do_plot
+        # View summed SIR dynamics for whole area
+        category_map = (
+            "Susceptible" => cat_idx[:, 1],
+            "Exposed" => cat_idx[:, 2],
+            "Asymptomatic" => cat_idx[:, 3],
+            "Presymptomatic" => cat_idx[:, 4],
+            "Symptomatic" => cat_idx[:, 5],
+            "Hospital" => cat_idx[:, 6],
+            "Recovered" => cat_idx[:, 7],
+            "Deaths" => cat_idx[:, 8],
+        )
+        display(plot_epidynamics(epi, abuns, category_map = category_map))
+        display(plot_epiheatmaps(epi, abuns, steps = [21]))
+    end
+    return abuns
 end
+
+times = 1year; interval = 1day; timestep = 1day
+abuns = run_model(times, interval, timestep);

--- a/examples/Epidemiology/Scotland_run.jl
+++ b/examples/Epidemiology/Scotland_run.jl
@@ -15,7 +15,7 @@ file, io = mktemp()
 r = HTTP.request("GET", "https://raw.githubusercontent.com/ScottishCovidResponse/temporary_data/master/human/demographics/scotland/data/demographics.h5")
 write(io, r.body)
 close(io)
-scotpop = parse_hdf5(file, grid = "10km", component = "grid10km/10year/persons")
+scotpop = parse_hdf5(file, grid = "1km", component = "grid1km/10year/persons")
 
 # Read number of age categories
 age_categories = size(scotpop, 3)
@@ -92,9 +92,11 @@ abun_v = (Virus = 0,)
 
 # Dispersal kernels for virus and disease classes
 dispersal_dists = fill(1.0km, numclasses * age_categories)
+thresholds = fill(1e-3, numclasses * age_categories)
 cat_idx = reshape(1:(numclasses * age_categories), age_categories, numclasses)
 dispersal_dists[vcat(cat_idx[:, 3:5]...)] .= 20.0km
-kernel = GaussianKernel.(dispersal_dists, 1e-10)
+thresholds[vcat(cat_idx[:, 3:5]...)] .= 1e-4
+kernel = GaussianKernel.(dispersal_dists, thresholds)
 movement = AlwaysMovement(kernel)
 
 # Traits for match to environment (turned off currently through param choice, i.e. virus matches environment perfectly)

--- a/examples/Epidemiology/Scotland_run.jl
+++ b/examples/Epidemiology/Scotland_run.jl
@@ -160,5 +160,5 @@ function run_model(times::Unitful.Time, interval::Unitful.Time, timestep::Unitfu
     return abuns
 end
 
-times = 1month; interval = 1day; timestep = 1day
-abunl(times, interval, timestep);
+times = 1year; interval = 1day; timestep = 1day
+abuns = run_model(times, interval, timestep);

--- a/examples/Epidemiology/UK_run.jl
+++ b/examples/Epidemiology/UK_run.jl
@@ -5,118 +5,120 @@ using Simulation.Units
 using Simulation.ClimatePref
 using StatsBase
 using Distributions
+using Plots
 
-do_plot = false
+function run_model(times::Unitful.Time, interval::Unitful.Time, timestep::Unitful.Time, do_plot::Bool = false)
+    # Set simulation parameters
+    age_categories = 10
+    numclasses = 8
+    numvirus = 1
+    birth_rates = fill(0.0/day, numclasses, age_categories)
+    death_rates = fill(0.0/day, numclasses, age_categories)
+    birth_rates[:, 2:4] .= uconvert(day^-1, 1/20years); death_rates[1:end-1, :] .= uconvert(day^-1, 1/100years)
+    virus_growth_asymp = virus_growth_presymp = virus_growth_symp = fill(0.1/day, age_categories)
+    virus_decay = 1.0/day
+    beta_force = fill(10.0/day, age_categories)
+    beta_env = fill(10.0/day, age_categories)
+    ageing = fill(0.0/day, age_categories - 1)# no ageing for now
 
-# Set simulation parameters
-age_categories = 10
-numclasses = 8
-numvirus = 1
-birth_rates = fill(0.0/day, numclasses, age_categories)
-death_rates = fill(0.0/day, numclasses, age_categories)
-birth_rates[:, 2:4] .= uconvert(day^-1, 1/20years); death_rates[1:end-1, :] .= uconvert(day^-1, 1/100years)
-virus_growth_asymp = virus_growth_presymp = virus_growth_symp = fill(0.1/day, age_categories)
-virus_decay = 1.0/day
-beta_force = fill(10.0/day, age_categories)
-beta_env = fill(10.0/day, age_categories)
-ageing = fill(0.0/day, age_categories - 1)# no ageing for now
+    # Prob of developing symptoms
+    p_s = fill(0.96, age_categories)
+    # Prob of hospitalisation
+    p_h = fill(0.2, age_categories)
+    # Case fatality ratio
+    cfr_home = cfr_hospital = fill(0.1, age_categories)
+    # Time exposed
+    T_lat = 3days
+    # Time asymptomatic
+    T_asym = 5days
+    # Time pre-symptomatic
+    T_presym = 1.5days
+    # Time symptomatic
+    T_sym = 5days
+    # Time in hospital
+    T_hosp = 5days
+    # Time to recovery if symptomatic
+    T_rec = 11days
 
-# Prob of developing symptoms
-p_s = fill(0.96, age_categories)
-# Prob of hospitalisation
-p_h = fill(0.2, age_categories)
-# Case fatality ratio
-cfr_home = cfr_hospital = fill(0.1, age_categories)
-# Time exposed
-T_lat = 3days
-# Time asymptomatic
-T_asym = 5days
-# Time pre-symptomatic
-T_presym = 1.5days
-# Time symptomatic
-T_sym = 5days
-# Time in hospital
-T_hosp = 5days
-# Time to recovery if symptomatic
-T_rec = 11days
+    param = SEI3HRDGrowth(birth_rates, death_rates, ageing,
+                          virus_growth_asymp, virus_growth_presymp, virus_growth_symp, virus_decay,
+                          beta_force, beta_env, p_s, p_h, cfr_home, cfr_hospital,
+                          T_lat, T_asym, T_presym, T_sym, T_hosp, T_rec)
+    param = transition(param, age_categories)
 
-param = SEI3HRDGrowth(birth_rates, death_rates, ageing,
-                      virus_growth_asymp, virus_growth_presymp, virus_growth_symp, virus_decay,
-                      beta_force, beta_env, p_s, p_h, cfr_home, cfr_hospital,
-                      T_lat, T_asym, T_presym, T_sym, T_hosp, T_rec)
-param = transition(param, age_categories)
+    # Read in population sizes for Scotland
+    ukpop = Array{Float64, 2}(readfile(Simulation.path("test", "examples",
+                                                       "UK.tif"),
+                                       0.0, 7e5, 0, 1.25e6))
+    # Coarsen grid to 10km
+    ukpop = [sum(ukpop[i:i+9, j:j+9]) for i in 1:10:size(ukpop, 1), j in 1:10:size(ukpop, 2)]
 
-# Read in population sizes for Scotland
-ukpop = Array{Float64, 2}(readfile(Simulation.path("test", "examples",
-                                                   "UK.tif"),
-                                   0.0, 7e5, 0, 1.25e6))
-# Coarsen grid to 10km
-ukpop = [sum(ukpop[i:i+9, j:j+9]) for i in 1:10:size(ukpop, 1), j in 1:10:size(ukpop, 2)]
+    # Set up simple gridded environment
+    area = 875_000.0km^2
+    epienv = simplehabitatAE(298.0K, area, NoControl(), ukpop)
 
-# Set up simple gridded environment
-area = 875_000.0km^2
-epienv = simplehabitatAE(298.0K, area, NoControl(), ukpop)
-
-# Set population to initially have no individuals
-abun_h = (
-    Susceptible = fill(0, age_categories),
-    Exposed = fill(0, age_categories),
-    Asymptomatic = fill(0, age_categories),
-    Presymptomatic = fill(0, age_categories),
-    Symptomatic = fill(0, age_categories),
-    Hospitalised = fill(0, age_categories),
-    Recovered = fill(0, age_categories),
-    Dead = fill(0, age_categories)
-)
-disease_classes = (
-    susceptible = ["Susceptible"],
-    infectious = ["Asymptomatic", "Presymptomatic", "Symptomatic"]
-)
-abun_v = (Virus = 0,)
-
-# Dispersal kernels for virus and disease classes
-dispersal_dists = fill(1.0km, numclasses * age_categories)
-cat_idx = reshape(1:(numclasses * age_categories), age_categories, numclasses)
-dispersal_dists[vcat(cat_idx[:, 3:5]...)] .= 20.0km
-kernel = GaussianKernel.(dispersal_dists, 1e-10)
-movement = AlwaysMovement(kernel)
-
-# Traits for match to environment (turned off currently through param choice, i.e. virus matches environment perfectly)
-traits = GaussTrait(fill(298.0K, numvirus), fill(0.1K, numvirus))
-epilist = EpiList(traits, abun_v, abun_h, disease_classes, movement, param, age_categories)
-rel = Gauss{eltype(epienv.habitat)}()
-
-# Create epi system with all information
-epi = EpiSystem(epilist, epienv, rel)
-
-# Spread susceptibles randomly over age categories
-split_pop = rand.(Multinomial.(Int.(epi.abundances.matrix[1, :]), 10))
-for j in 1:size(epi.abundances.matrix, 2)
-    epi.abundances.matrix[cat_idx[:, 1], j] .= split_pop[j]
-end
-
-# Add in initial infections randomly (samples weighted by population size)
-N_cells = size(epi.abundances.matrix, 2)
-samp = sample(1:N_cells, weights(1.0 .* epi.abundances.matrix[1, :]), 100)
-epi.abundances.matrix[vcat(cat_idx[:, 2]...), samp] .= 10 # Exposed pop
-
-# Run simulation
-abuns = zeros(Int64, size(epi.abundances.matrix, 1), N_cells, 366)
-times = 2months; interval = 1day; timestep = 1day
-@time simulate_record!(abuns, epi, times, interval, timestep)
-
-if do_plot
-    using Plots
-    # View summed SIR dynamics for whole area
-    category_map = (
-        "Susceptible" => cat_idx[:, 1],
-        "Exposed" => cat_idx[:, 2],
-        "Asymptomatic" => cat_idx[:, 3],
-        "Presymptomatic" => cat_idx[:, 4],
-        "Symptomatic" => cat_idx[:, 5],
-        "Hospital" => cat_idx[:, 6],
-        "Recovered" => cat_idx[:, 7],
-        "Deaths" => cat_idx[:, 8],
+    # Set population to initially have no individuals
+    abun_h = (
+        Susceptible = fill(0, age_categories),
+        Exposed = fill(0, age_categories),
+        Asymptomatic = fill(0, age_categories),
+        Presymptomatic = fill(0, age_categories),
+        Symptomatic = fill(0, age_categories),
+        Hospitalised = fill(0, age_categories),
+        Recovered = fill(0, age_categories),
+        Dead = fill(0, age_categories)
     )
-    display(plot_epidynamics(epi, abuns; category_map=category_map))
+    disease_classes = (
+        susceptible = ["Susceptible"],
+        infectious = ["Asymptomatic", "Presymptomatic", "Symptomatic"]
+    )
+    abun_v = (Virus = 0,)
+
+    # Dispersal kernels for virus and disease classes
+    dispersal_dists = fill(1.0km, numclasses * age_categories)
+    cat_idx = reshape(1:(numclasses * age_categories), age_categories, numclasses)
+    dispersal_dists[vcat(cat_idx[:, 3:5]...)] .= 20.0km
+    kernel = GaussianKernel.(dispersal_dists, 1e-10)
+    movement = AlwaysMovement(kernel)
+
+    # Traits for match to environment (turned off currently through param choice, i.e. virus matches environment perfectly)
+    traits = GaussTrait(fill(298.0K, numvirus), fill(0.1K, numvirus))
+    epilist = EpiList(traits, abun_v, abun_h, disease_classes, movement, param, age_categories)
+    rel = Gauss{eltype(epienv.habitat)}()
+
+    # Create epi system with all information
+    epi = EpiSystem(epilist, epienv, rel)
+
+    # Spread susceptibles randomly over age categories
+    split_pop = rand.(Multinomial.(Int.(epi.abundances.matrix[1, :]), 10))
+    for j in 1:size(epi.abundances.matrix, 2)
+        epi.abundances.matrix[cat_idx[:, 1], j] .= split_pop[j]
+    end
+
+    # Add in initial infections randomly (samples weighted by population size)
+    N_cells = size(epi.abundances.matrix, 2)
+    samp = sample(1:N_cells, weights(1.0 .* epi.abundances.matrix[1, :]), 100)
+    epi.abundances.matrix[vcat(cat_idx[:, 2]...), samp] .= 10 # Exposed pop
+
+    # Run simulation
+    abuns = zeros(Int64, size(epi.abundances.matrix, 1), N_cells, 366)
+    @time simulate_record!(abuns, epi, times, interval, timestep)
+
+    if do_plot
+        # View summed SIR dynamics for whole area
+        category_map = (
+            "Susceptible" => cat_idx[:, 1],
+            "Exposed" => cat_idx[:, 2],
+            "Asymptomatic" => cat_idx[:, 3],
+            "Presymptomatic" => cat_idx[:, 4],
+            "Symptomatic" => cat_idx[:, 5],
+            "Hospital" => cat_idx[:, 6],
+            "Recovered" => cat_idx[:, 7],
+            "Deaths" => cat_idx[:, 8],
+        )
+        display(plot_epidynamics(epi, abuns; category_map=category_map))
+    end
 end
+
+times = 1year; interval = 1day; timestep = 1day
+abuns = run_model(times, interval, timestep);

--- a/src/Biodiversity/Habitats.jl
+++ b/src/Biodiversity/Habitats.jl
@@ -236,11 +236,11 @@ function _getgridsize(hab::Union{HabitatCollection2, HabitatCollection3})
   return _getgridsize(hab.h1)
 end
 
-function gethabitat(hab::AbstractHabitat, pos::Int64)
+function gethabitat(hab::H, pos::Int64) where H <: AbstractHabitat
     x, y = convert_coords(pos, size(hab.matrix, 1))
     return hab.matrix[x, y]
 end
-function gethabitat(hab::AbstractHabitat, field::Symbol)
+function gethabitat(hab::H, field::Symbol) where H <: AbstractHabitat
     return getfield(hab, field)
 end
 function gethabitat(hab::ContinuousTimeHab, pos::Int64)

--- a/src/Biodiversity/TraitRelationship.jl
+++ b/src/Biodiversity/TraitRelationship.jl
@@ -22,7 +22,8 @@ mutable struct Gauss{TR} <: AbstractTraitRelationship{TR}
 end
 
 function (::Gauss{TR})(current::TR, opt::TR, var::TR) where TR
-    return (1.0 * unit(current))/sqrt(2 * π * var^2) * exp(-abs(current - opt)^2/(2 * var^2))
+    pref = (1.0)/sqrt(2 * π * var^2) * exp(-abs(current - opt)^2/(2 * var^2))
+    return pref * unit(current)
 end
 iscontinuous(tr::Gauss{TR}) where TR = true
 function eltype(tr::Gauss{TR}) where TR

--- a/src/Biodiversity/Traitfuns.jl
+++ b/src/Biodiversity/Traitfuns.jl
@@ -8,7 +8,7 @@ function traitfun(eco::AbstractEcosystem, pos::Int64, sp::Int64)
     hab = eco.abenv.habitat
     trts = eco.spplist.traits
     rel = eco.relationship
-  _traitfun(hab, trts, rel, pos, sp)
+    _traitfun(hab, trts, rel, pos, sp)
 end
 
 function _traitfun(hab::HabitatCollection2, trts::TraitCollection2, rel::R, pos::Int64, sp::Int64) where R <: AbstractTraitRelationship
@@ -18,8 +18,9 @@ function _traitfun(hab::HabitatCollection2, trts::TraitCollection2, rel::R, pos:
 end
 function _traitfun(hab::ContinuousHab, trts::GaussTrait,
     rel::R, pos::Int64, sp::Int64) where R <: AbstractTraitRelationship
-        mean, var = getpref(trts, sp)
-    return rel(hab.matrix[pos], mean, var)
+    h = hab.matrix[pos]
+    mean, var = getpref(trts, sp)
+    return rel(h, mean, var)
 end
 function _traitfun(hab::ContinuousTimeHab, trts::GaussTrait,
     rel::R, pos::Int64, sp::Int64) where R <: AbstractTraitRelationship

--- a/src/Biodiversity/Traitfuns.jl
+++ b/src/Biodiversity/Traitfuns.jl
@@ -18,9 +18,8 @@ function _traitfun(hab::HabitatCollection2, trts::TraitCollection2, rel::R, pos:
 end
 function _traitfun(hab::ContinuousHab, trts::GaussTrait,
     rel::R, pos::Int64, sp::Int64) where R <: AbstractTraitRelationship
-        h = gethabitat(hab, pos)
         mean, var = getpref(trts, sp)
-    return rel(h, mean, var)
+    return rel(hab.matrix[pos], mean, var)
 end
 function _traitfun(hab::ContinuousTimeHab, trts::GaussTrait,
     rel::R, pos::Int64, sp::Int64) where R <: AbstractTraitRelationship

--- a/src/Epidemiology/EpiEnv.jl
+++ b/src/Epidemiology/EpiEnv.jl
@@ -21,19 +21,19 @@ abstract type AbstractEpiEnv{H <: AbstractHabitat, C <: AbstractControl} <:
 This epi environment type holds a habitat and control strategy, as well as a string of
 subcommunity names, and initial susceptible population.
 """
-mutable struct GridEpiEnv{H, C} <: AbstractEpiEnv{H, C}
+mutable struct GridEpiEnv{H, C, A, P} <: AbstractEpiEnv{H, C}
     habitat::H
-    active::AbstractMatrix{Bool}
+    active::A
     control::C
-    initial_population::AbstractMatrix{Int}
+    initial_population::P
     names::Vector{String}
     function (::Type{GridEpiEnv{H, C}})(
         habitat::H,
-        active::AbstractMatrix{Bool},
+        active::A,
         control::C,
-        initial_population=zeros(Int, _getdimension(habitat)),
+        initial_population::P=zeros(Int, _getdimension(habitat)),
         names::Vector{String}=map(x -> "$x", 1:countsubcommunities(habitat))
-    ) where {H, C}
+    ) where {H, C, A <: AbstractMatrix{Bool}, P <: AbstractMatrix{Int}}
         countsubcommunities(habitat) == length(names) ||
             error("Number of subcommunities must match subcommunity names")
         if size(habitat.matrix) != size(active)
@@ -48,7 +48,7 @@ mutable struct GridEpiEnv{H, C} <: AbstractEpiEnv{H, C}
                 "size(active)=$(size(active))"
             ))
         end
-        return new{H, C}(habitat, active, control, initial_population, names)
+        return new{H, C, A, P}(habitat, active, control, initial_population, names)
     end
 end
 
@@ -67,7 +67,7 @@ end
 Shrink the matrix `M` to the minimum rectangular region which contains all active cells, as
 defined by `active`. Returns the shrunk matrix.
 """
-function _shrink_to_active(M::AbstractMatrix, active::AbstractMatrix{<:Bool})
+function _shrink_to_active(M::AM, active::A) where {AM <: AbstractMatrix, A <: AbstractMatrix{<: Bool}}
     if size(M) != size(active)
         throw(DimensionMismatch("size(M)=$(size(M)) != size(active)=$(size(active))"))
     end
@@ -127,10 +127,10 @@ function simplehabitatAE(
     val::Union{Float64, Unitful.Quantity{Float64}},
     dimension::Tuple{Int64, Int64},
     area::Unitful.Area{Float64},
-    active::AbstractMatrix{Bool},
+    active::M,
     control::C,
-    initial_population::AbstractMatrix{<:Integer}=zeros(Int, dimension),
-) where C <: AbstractControl
+    initial_population::P=zeros(Int, dimension),
+) where {C <: AbstractControl, M <: AbstractMatrix{Bool}, P <: AbstractMatrix{<:Integer}}
     if typeof(val) <: Unitful.Temperature
         val = uconvert(K, val)
     end
@@ -184,8 +184,8 @@ function simplehabitatAE(
     val::Union{Float64, Unitful.Quantity{Float64}},
     area::Unitful.Area{Float64},
     control::C,
-    initial_population::AbstractMatrix{<:Real},
-) where C <: AbstractControl
+    initial_population::M,
+) where {C <: AbstractControl, M <: AbstractMatrix{<:Real}}
     inactive(x) = isnan(x) || ismissing(x)
     if all(inactive.(initial_population))
         throw(ArgumentError("initial_population is all NaN / missing"))

--- a/src/Epidemiology/EpiGenerate.jl
+++ b/src/Epidemiology/EpiGenerate.jl
@@ -81,7 +81,7 @@ end
     sum_pop(M::Matrix{Int64}, i::Int64)
 Function to sum a population matrix, `M`, without memory allocation, at a grid location `i`.
 """
-function sum_pop(M::Matrix{Int64}, i::Int64)
+function sum_pop(M::Matrix{U}, i::Int64) where U <: Integer
     N = 0
     for j in 1:size(M, 1)
         N += M[j, i]

--- a/src/Epidemiology/EpiGenerate.jl
+++ b/src/Epidemiology/EpiGenerate.jl
@@ -81,28 +81,20 @@ end
     sum_pop(M::Matrix{Int64}, i::Int64)
 Function to sum a population matrix, `M`, without memory allocation, at a grid location `i`.
 """
-function sum_pop(M::Matrix{U}, i::Int64) where U <: Integer
-    N = 0
+function sum_pop(M::Matrix{R}, i::Int64) where R <: Real
+    n = zero(R)
     for j in 1:size(M, 1)
-        N += M[j, i]
+        n += M[j, i]
     end
-    return N
+    return n
 end
 
-function sum_pop(M::Matrix{Float64}, i::Int64)
-    N = 0
-    for j in 1:size(M, 1)
-        N += M[j, i]
-    end
-    return N
-end
-
-function sum_pop(V::Vector{Float64})
-    N = 0
+function sum_pop(M::vector{R}) where R <: Real
+    n = zero(R)
     for i in 1:length(V)
-        N += V[i]
+        n += V[i]
     end
-    return N
+    return n
 end
 
 

--- a/src/Epidemiology/EpiGenerate.jl
+++ b/src/Epidemiology/EpiGenerate.jl
@@ -96,6 +96,14 @@ function sum_pop(M::Matrix{Float64}, i::Int64)
     return N
 end
 
+function sum_pop(V::Vector{Float64})
+    N = 0
+    for i in 1:length(V)
+        N += V[i]
+    end
+    return N
+end
+
 
 """
     classupdate!(epi::EpiSystem, timestep::Unitful.Time)
@@ -218,8 +226,8 @@ function calc_lookup_moves!(bound::NoBoundary, x::Int64, y::Int64, id::Int64, ep
         lookuppnew[i] = lookuppi
     end
     # Case that produces NaN (if sum(lookup.pnew) also pnew always .>= 0) dealt with above
-    lookup.pnew ./= sum(lookup.pnew)
-    lookup.moves .= abun .* lookup.pnew
+    lookuppnew ./= sum_pop(lookuppnew)
+    lookup.moves .= abun .* lookuppnew
     return nothing
 end
 

--- a/src/Epidemiology/EpiGenerate.jl
+++ b/src/Epidemiology/EpiGenerate.jl
@@ -78,21 +78,21 @@ function virusupdate!(epi::EpiSystem, timestep::Unitful.Time)
 end
 
 """
-    sum_pop(M::Matrix{Int64}, i::Int64)
-Function to sum a population matrix, `M`, without memory allocation, at a grid location `i`.
+    sum_pop(m::Matrix{Int64}, i::Int64)
+Function to sum a population matrix, `m`, without memory allocation, at a grid location `i`.
 """
-function sum_pop(M::Matrix{R}, i::Int64) where R <: Real
+function sum_pop(m::Matrix{R}, i::Int64) where R <: Real
     n = zero(R)
-    for j in 1:size(M, 1)
-        n += M[j, i]
+    @inbounds for j in 1:size(m, 1)
+        n += m[j, i]
     end
     return n
 end
 
-function sum_pop(M::Vector{R}) where R <: Real
+function sum_pop(v::Vector{R}) where R <: Real
     n = zero(R)
-    for i in 1:length(V)
-        n += V[i]
+    @inbounds for i in 1:length(v)
+        n += v[i]
     end
     return n
 end

--- a/src/Epidemiology/EpiGenerate.jl
+++ b/src/Epidemiology/EpiGenerate.jl
@@ -89,7 +89,7 @@ function sum_pop(M::Matrix{R}, i::Int64) where R <: Real
     return n
 end
 
-function sum_pop(M::vector{R}) where R <: Real
+function sum_pop(M::Vector{R}) where R <: Real
     n = zero(R)
     for i in 1:length(V)
         n += V[i]

--- a/src/Epidemiology/EpiHelper.jl
+++ b/src/Epidemiology/EpiHelper.jl
@@ -175,7 +175,7 @@ function initialise_output_abuns(
         dset_abuns = d_create(
             group,
             "abuns",
-            datatype(typeof(abuns[1])),
+            datatype(eltype(abuns)),
             dataspace(size(abuns)),
             "chunk",
             (size.(Ref(abuns), [1,2])...,1)

--- a/src/Epidemiology/EpiHelper.jl
+++ b/src/Epidemiology/EpiHelper.jl
@@ -102,7 +102,7 @@ function simulate_record!(
   axes = (;
       compartment = epi.epilist.human.names,
       grid_id = grid_id,
-      times = string.(record_seq)
+      times = string.(uconvert.(day, 1.0 .* record_seq))
   )
   if save
       initialise_output_abuns(
@@ -175,7 +175,7 @@ function initialise_output_abuns(
         dset_abuns = d_create(
             group,
             "abuns",
-            datatype(Int),
+            datatype(typeof(abuns[1])),
             dataspace(size(abuns)),
             "chunk",
             (size.(Ref(abuns), [1,2])...,1)
@@ -197,10 +197,10 @@ end
 Update the existing HDF5 file `h5fn` with the abundance matrix at a certain timestep.
 """
 function update_output_abuns(
-    abuns_t::Matrix,
+    abuns_t::Matrix{U},
     timestep::Int;
     h5fn=joinpath(pwd(),"abundances.h5")
-)
+) where U <: Integer
     if !(isfile(h5fn) && ishdf5(h5fn))
         throw(ArgumentError(
             "$(h5fn) does not exist or is not a valid HDF5 file"

--- a/src/Epidemiology/EpiLandscape.jl
+++ b/src/Epidemiology/EpiLandscape.jl
@@ -4,15 +4,15 @@
 Disease class abundances housed in the landscape. These are represented in both 2 dimensions (for computational efficiency in simulations) and 3 dimensions (to represent disease classes, their abundances and position in the grid).
 
 """
-mutable struct EpiLandscape
-  matrix::Matrix{Int64}
-  matrix_v::Matrix{Int64}
-  grid::Array{Int64, 3}
+mutable struct EpiLandscape{U <: Integer}
+  matrix::Matrix{U}
+  matrix_v::Matrix{U}
+  grid::Array{U, 3}
   seed::Vector{MersenneTwister}
-  function EpiLandscape(human_abun::Matrix{Int64}, virus_abun::Matrix{Int64}, d1::Tuple)
+  function EpiLandscape{U}(human_abun::Matrix{U}, virus_abun::Matrix{U}, d1::Tuple) where U <: Integer
     return new(human_abun, virus_abun, reshape(human_abun, d1), [MersenneTwister(rand(UInt)) for _ in 1:Threads.nthreads()])
   end
-  function EpiLandscape(human_abun::Matrix{Int64}, virus_abun::Matrix{Int64}, d1::Tuple, d2::Tuple, seed::Vector{MersenneTwister})
+  function EpiLandscape{U}(human_abun::Matrix{U}, virus_abun::Matrix{U}, d1::Tuple, d2::Tuple, seed::Vector{MersenneTwister}) where U <: Integer
     return new(human_abun, virus_abun, reshape(human_abun, d1), seed)
   end
 end
@@ -35,9 +35,9 @@ end
 Function to create an empty EpiLandscape given a GridEpiEnv and a
 EpiList.
 """
-function emptyepilandscape(epienv::GridEpiEnv, epilist::EpiList)
-  mat_human = zeros(Int64, counttypes(epilist.human, true), countsubcommunities(epienv))
-  mat_virus = zeros(Int64, counttypes(epilist.virus, true), countsubcommunities(epienv))
+function emptyepilandscape(epienv::GridEpiEnv, epilist::EpiList, IntType::U) where U <: Integer
+  mat_human = zeros(U, counttypes(epilist.human, true), countsubcommunities(epienv))
+  mat_virus = zeros(U, counttypes(epilist.virus, true), countsubcommunities(epienv))
   dimension = (counttypes(epilist.human, true), _getdimension(epienv.habitat)...)
-  return EpiLandscape(mat_human, mat_virus, dimension)
+  return EpiLandscape{U}(mat_human, mat_virus, dimension)
 end

--- a/src/Epidemiology/EpiLandscape.jl
+++ b/src/Epidemiology/EpiLandscape.jl
@@ -35,7 +35,7 @@ end
 Function to create an empty EpiLandscape given a GridEpiEnv and a
 EpiList.
 """
-function emptyepilandscape(epienv::GridEpiEnv, epilist::EpiList, IntType::U) where U <: Integer
+function emptyepilandscape(epienv::GridEpiEnv, epilist::EpiList, intnum::U) where U <: Integer
   mat_human = zeros(U, counttypes(epilist.human, true), countsubcommunities(epienv))
   mat_virus = zeros(U, counttypes(epilist.virus, true), countsubcommunities(epienv))
   dimension = (counttypes(epilist.human, true), _getdimension(epienv.habitat)...)

--- a/src/Epidemiology/EpiList.jl
+++ b/src/Epidemiology/EpiList.jl
@@ -52,13 +52,13 @@ end
     EpiList{P <: AbstractParams} <: AbstractTypes
 Epi list houses all disease and virus class specific information, as well as parameters for model runs.
 """
-mutable struct EpiList{P <: AbstractParams} <: AbstractTypes
-    virus::VirusTypes
-    human::HumanTypes
+mutable struct EpiList{P <: AbstractParams, V <: VirusTypes, H <: HumanTypes} <: AbstractTypes
+    virus::V
+    human::H
     params::P
 
-    function EpiList{P}(virus::VirusTypes, human::HumanTypes, param::P) where {P <: AbstractParams}
-      new{P}(virus, human, param)
+    function EpiList{P, V, H}(virus::V, human::H, param::P) where {P <: AbstractParams, V <: VirusTypes, H <: HumanTypes}
+      new{P, V, H}(virus, human, param)
     end
 end
 
@@ -150,5 +150,5 @@ function EpiList(traits::TR, virus_abun::NamedTuple, human_abun::NamedTuple,
         throw(DimensionMismatch("Trait vector doesn't match number of virus classes"))
     size(param.transition, 1) == length(new_names) ||
         throw(DimensionMismatch("Transition matrix doesn't match number of disease classes"))
-    return EpiList{typeof(param)}(virus, human, param)
+    return EpiList{typeof(param), typeof(virus), typeof(human)}(virus, human, param)
 end

--- a/src/Epidemiology/EpiSystem.jl
+++ b/src/Epidemiology/EpiSystem.jl
@@ -10,8 +10,8 @@ abstract type AbstractEpiSystem{Part <: AbstractEpiEnv, EL <: EpiList, TR <: Abs
 
 
 mutable struct EpiCache
-  virusdecay::Array{Int64, 2}
-  virusmigration::Array{Int64, 2}
+  virusdecay::Array{Float64, 2}
+  virusmigration::Array{Float64, 2}
   valid::Bool
 end
 
@@ -22,7 +22,7 @@ mutable struct EpiLookup
   y::Vector{Int64}
   p::Vector{Float64}
   pnew::Vector{Float64}
-  moves::Vector{Int64}
+  moves::Vector{Float64}
 end
 EpiLookup(df::DataFrame) = EpiLookup(df[!, :X], df[!, :Y], df[!, :Prob],
 zeros(Float64, nrow(df)), zeros(Int64, nrow(df)))

--- a/src/Epidemiology/EpiSystem.jl
+++ b/src/Epidemiology/EpiSystem.jl
@@ -52,10 +52,10 @@ mutable struct EpiSystem{U <: Integer, EE <: AbstractEpiEnv, EL <: EpiList, ER <
 end
 
 function EpiSystem(popfun::F, epilist::EpiList, epienv::GridEpiEnv,
-    rel::AbstractTraitRelationship, IntType::U) where {F<:Function, U <: Integer}
+    rel::AbstractTraitRelationship, intnum::U) where {F<:Function, U <: Integer}
 
   # Create matrix landscape of zero abundances
-  ml = emptyepilandscape(epienv, epilist, IntType)
+  ml = emptyepilandscape(epienv, epilist, intnum)
   # Populate this matrix with species abundances
   popfun(ml, epilist, epienv, rel)
   # Create lookup table of all moves and their probabilities
@@ -65,8 +65,8 @@ function EpiSystem(popfun::F, epilist::EpiList, epienv::GridEpiEnv,
   EpiSystem{U, typeof(epienv), typeof(epilist), typeof(rel)}(ml, epilist, epienv, missing, rel, lookup_tab, EpiCache(nm, vm, false))
 end
 
-function EpiSystem(epilist::EpiList, epienv::GridEpiEnv, rel::AbstractTraitRelationship, IntType::U = Int64(1)) where U <: Integer
-    epi = EpiSystem(populate!, epilist, epienv, rel, IntType)
+function EpiSystem(epilist::EpiList, epienv::GridEpiEnv, rel::AbstractTraitRelationship, intnum::U = Int64(1)) where U <: Integer
+    epi = EpiSystem(populate!, epilist, epienv, rel, intnum)
     # Add in the initial susceptible population
     idx = findfirst(epilist.human.names .== "Susceptible")
     if idx == nothing

--- a/src/Epidemiology/EpiTraits.jl
+++ b/src/Epidemiology/EpiTraits.jl
@@ -6,7 +6,9 @@ Function to calculate relationship between the current environment and a particu
 """
 function traitfun(epi::AbstractEpiSystem, pos::Int64, sp::Int64)
     hab = epi.epienv.habitat
-    trts = epi.epilist.virus.traits
+    trts = gettraits(epi)
     rel = epi.relationship
     return _traitfun(hab, trts, rel, pos, sp)
 end
+
+gettraits(epi::EpiSystem) = epi.epilist.virus.traits

--- a/src/Epidemiology/EpiTraits.jl
+++ b/src/Epidemiology/EpiTraits.jl
@@ -8,5 +8,5 @@ function traitfun(epi::AbstractEpiSystem, pos::Int64, sp::Int64)
     hab = epi.epienv.habitat
     trts = epi.epilist.virus.traits
     rel = epi.relationship
-  _traitfun(hab, trts, rel, pos, sp)
+    return _traitfun(hab, trts, rel, pos, sp)
 end

--- a/test/test_EpiLandscape.jl
+++ b/test/test_EpiLandscape.jl
@@ -9,8 +9,8 @@ include("TestCases.jl")
 
 epi = TestEpiSystem()
 
-@test_nowarn emptyepilandscape(epi.epienv, epi.epilist)
-el = emptyepilandscape(epi.epienv, epi.epilist)
+@test_nowarn emptyepilandscape(epi.epienv, epi.epilist, Int64(1))
+el = emptyepilandscape(epi.epienv, epi.epilist, Int64(1))
 @test size(el.grid, 2) * size(el.grid, 3) == size(el.matrix, 2)
 @test size(el.grid, 1) == size(el.matrix, 1)
 @test sum(el.grid) == sum(el.matrix)


### PR DESCRIPTION
Changed virus loop to be calculated deterministically and randomised at end, along with other speed ups to `virusmove!`, which runs very slowly with multiple age classes.

`Scotland_run.jl` should now take ~12 mins to run 1 year  on 1km grid on a 30 core machine, rather than 3.5hrs previously! Still more to do - have identified allocations in `traitfun` and type instability in `epienv`.
EDIT: now ~9mins and all type stable
EDIT2: can be reduced even further (4mins) by altering the threshold parameter in virus movement - at the moment this is set too low and so is doing unnecessary calculations.

Closes ScottishCovidResponse/SCRCIssueTracking#426 and also closes ScottishCovidResponse/SCRCIssueTracking#408