### PR TITLE
Store force of infection as well as environmental virus

### DIFF
--- a/examples/Epidemiology/SEI3HRD_example.jl
+++ b/examples/Epidemiology/SEI3HRD_example.jl
@@ -7,7 +7,7 @@ using StatsBase
 
 do_plot = false
 
-numvirus = 1
+numvirus = 2
 numclasses = 8
 
 # Set simulation parameters
@@ -63,7 +63,7 @@ disease_classes = (
     susceptible = ["Susceptible"],
     infectious = ["Asymptomatic", "Presymptomatic", "Symptomatic"]
 )
-abun_v = (Virus = 0,)
+abun_v = (Environment = 0, Force = 0)
 
 # Dispersal kernels for virus and disease classes
 dispersal_dists = fill(2.0km, numclasses)
@@ -81,7 +81,7 @@ epi = EpiSystem(epilist, epienv, rel)
 # Add in initial infections randomly (samples weighted by population size)
 N_cells = size(epi.abundances.matrix, 2)
 samp = sample(1:N_cells, weights(1.0 .* human(epi.abundances)[1, :]), 100)
-virus(epi.abundances)[1, samp] .= 100 # Virus pop
+virus(epi.abundances)[1, samp] .= 100 # Virus pop in Environment
 human(epi.abundances)[2, samp] .= 10 # Exposed pop
 
 # Run simulation

--- a/examples/Epidemiology/Scotland_run.jl
+++ b/examples/Epidemiology/Scotland_run.jl
@@ -33,7 +33,7 @@ total_pop.data[total_pop .≈ 0.0] .= NaN
 
 # Set simulation parameters
 numclasses = 8
-numvirus = 1
+numvirus = 2
 birth_rates = fill(0.0/day, numclasses, age_categories)
 death_rates = fill(0.0/day, numclasses, age_categories)
 birth_rates[:, 2:4] .= uconvert(day^-1, 1/20years)
@@ -88,7 +88,7 @@ disease_classes = (
     infectious = ["Asymptomatic", "Presymptomatic", "Symptomatic"]
 )
 
-abun_v = (Virus = 0,)
+abun_v = (Environment = 0, Force = 0)
 
 # Dispersal kernels for virus and disease classes
 dispersal_dists = fill(1.0km, numclasses * age_categories)

--- a/examples/Epidemiology/UK_run.jl
+++ b/examples/Epidemiology/UK_run.jl
@@ -11,7 +11,7 @@ do_plot = false
 # Set simulation parameters
 age_categories = 10
 numclasses = 8
-numvirus = 1
+numvirus = 2
 birth_rates = fill(0.0/day, numclasses, age_categories)
 death_rates = fill(0.0/day, numclasses, age_categories)
 birth_rates[:, 2:4] .= uconvert(day^-1, 1/20years); death_rates[1:end-1, :] .= uconvert(day^-1, 1/100years)
@@ -72,7 +72,7 @@ disease_classes = (
     susceptible = ["Susceptible"],
     infectious = ["Asymptomatic", "Presymptomatic", "Symptomatic"]
 )
-abun_v = (Virus = 0,)
+abun_v = (Environment = 0, Force = 0)
 
 # Dispersal kernels for virus and disease classes
 dispersal_dists = fill(1.0km, numclasses * age_categories)

--- a/src/Epidemiology/EpiGenerate.jl
+++ b/src/Epidemiology/EpiGenerate.jl
@@ -50,7 +50,7 @@ function virusupdate!(epi::EpiSystem, timestep::Unitful.Time)
                 # Convert death rate into 0 - 1 probability
                 deathprob = 1.0 - exp(-deathrate)
 
-                (birthrate >= 0) & (deathprob >= 0) || error("Birth: $birthprob \n Death: $newdeathprob \n \n i: $i")
+                (birthrate >= 0) & (deathprob >= 0) || error("Birth: $birthprob \n Death: $deathprob \n \n i: $i")
                 # Calculate how many births and deaths
                 births = rand(rng, Poisson(birthrate))
                 deaths = rand(rng, Binomial(virus(epi.abundances)[1, i], deathprob))
@@ -65,7 +65,7 @@ function virusupdate!(epi::EpiSystem, timestep::Unitful.Time)
     vm = sum(epi.cache.virusmigration, dims = 1)[1, :]
     nm = sum(epi.cache.virusdecay, dims = 1)[1, :]
     virus(epi.abundances)[1, :] .+= (nm .+ vm)
-    epi.cache.virusmigration[1, :] .+= vm
+    virus(epi.abundances)[2, :] = vm
 end
 
 """
@@ -115,7 +115,7 @@ function classupdate!(epi::EpiSystem, timestep::Unitful.Time)
                 iszero(human(epi.abundances)[k, i]) && continue # will result +=/-= 0 at end of loop
                 env_inf = (params.transition_virus[j, k] * timestep * virus(epi.abundances)[1, i]) / N
 
-                force_inf = (params.transition_force[j, k] * timestep * epi.cache.virusmigration[1, i]) / N
+                force_inf = (params.transition_force[j, k] * timestep * virus(epi.abundances)[2, i]) / N
 
                 # Add to transitional probabilities
                 trans_val = (params.transition[j, k] * timestep) + env_inf + force_inf
@@ -293,4 +293,3 @@ function quickmod(x::T, h::T) where {T<:Integer}
     end
     return x
 end
-

--- a/src/Epidemiology/EpiList.jl
+++ b/src/Epidemiology/EpiList.jl
@@ -135,8 +135,7 @@ function EpiList(traits::TR, virus_abun::NamedTuple, human_abun::NamedTuple,
                                                      ht, movement, sus, inf)
 
     virus_names = collect(string.(keys(virus_abun)))
-    virus_names = [ifelse(i == 1, "$(virus_names[i])", "$(virus_names[i])$i")
-                   for i in 1:length(virus_abun)]
+
     vt = UniqueTypes(length(virus_names))
     virus = VirusTypes{typeof(traits), typeof(vt)}(virus_names, traits, vcat(collect(virus_abun)...), vt)
 

--- a/src/Epidemiology/Inference.jl
+++ b/src/Epidemiology/Inference.jl
@@ -22,7 +22,7 @@ Fills an abundance matrice of compartment by grid cell over time. Compartments f
 function SIR_wrapper!(grid_size::Tuple{Int64, Int64}, area::Unitful.Area{Float64}, params::NamedTuple, runtimes::NamedTuple, abuns::Array{Int64, 3})
     # Set up
     numclasses = 4
-    numvirus = 1
+    numvirus = 2
     Ncells = grid_size[1] * grid_size[2]
 
     # Extract model params from tuple
@@ -53,8 +53,7 @@ function SIR_wrapper!(grid_size::Tuple{Int64, Int64}, area::Unitful.Area{Float64
         susceptible = ["Susceptible"],
         infectious = ["Infected"]
     )
-    abun_v = (
-        Virus = 0,)
+    abun_v = (Environment = 0, Force = 0)
 
     # Dispersal kernels for virus and disease classes
     dispersal_dists = fill(sqrt(area/Ncells)/5, numclasses)

--- a/test/TestCases.jl
+++ b/test/TestCases.jl
@@ -38,7 +38,7 @@ function TestEcosystem()
     return eco
 end
 function TestEpiSystem()
-    numvirus = 1
+    numvirus = 2
     numclasses = 4
     birth = [fill(1e-5/day, numclasses - 1); 0.0/day]
     death = [fill(1e-5/day, numclasses - 1); 0.0/day]
@@ -64,7 +64,7 @@ function TestEpiSystem()
         susceptible = ["Susceptible"],
         infectious = ["Infected"]
     )
-    abun_v = (Virus = 10,)
+    abun_v = (Environment = 0, Force = 0)
 
     dispersal_dists = [fill(2.0km, numclasses - 1); 1e-2km]
     kernel = GaussianKernel.(dispersal_dists, 1e-10)
@@ -80,7 +80,7 @@ function TestEpiSystem()
 end
 function TestEpiSystemFromPopulation(initial_pop::Matrix{<:Real})
     numclasses = 4
-    numvirus = 1
+    numvirus = 2
     birth = [fill(1e-5/day, numclasses - 1); 0.0/day]
     death = [fill(1e-5/day, numclasses - 1); 0.0/day]
     beta_force = 5.0/day
@@ -105,7 +105,7 @@ function TestEpiSystemFromPopulation(initial_pop::Matrix{<:Real})
         susceptible = ["Susceptible"],
         infectious = ["Infected"]
     )
-    abun_v = (Virus = 10,)
+    abun_v = (Environment = 0, Force = 0)
 
     dispersal_dists = [fill(2.0km, numclasses - 1); 1e-2km]
     kernel = GaussianKernel.(dispersal_dists, 1e-10)

--- a/test/canonical/test_SEI2HRD.jl
+++ b/test/canonical/test_SEI2HRD.jl
@@ -15,7 +15,7 @@ save_path = (@isdefined save_path) ? save_path : pwd()
 ##
 # Set simulation parameters
 numclasses = 7
-numvirus = 1
+numvirus = 2
 birth = fill(0.0/day, numclasses)
 death = fill(0.0/day, numclasses)
 virus_growth_asymp = virus_growth_symp = 1e-3/day
@@ -62,7 +62,7 @@ disease_classes = (
   susceptible = ["Susceptible"],
   infectious = ["Asymptomatic", "Symptomatic"]
 )
-abun_v = (Virus = 0,)
+abun_v = (Environment = 0, Force = 0)
 
 # Dispersal kernels for virus dispersal from different disease classes
 dispersal_dists = fill(1.0km, numclasses)
@@ -142,7 +142,7 @@ disease_classes = (
   susceptible = ["Susceptible"],
   infectious = ["Asymptomatic", "Symptomatic"]
 )
-abun_v = (Virus = 0,)
+abun_v = (Environment = 0, Force = 0)
 
 # Dispersal kernels for virus dispersal from different disease classes
 dispersal_dists = fill(1.0km, numclasses)

--- a/test/canonical/test_SEI3HRD.jl
+++ b/test/canonical/test_SEI3HRD.jl
@@ -15,7 +15,7 @@ save_path = (@isdefined save_path) ? save_path : pwd()
 ##
 # Set simulation parameters
 numclasses = 8
-numvirus = 1
+numvirus = 2
 birth = fill(0.0/day, numclasses)
 death = fill(0.0/day, numclasses)
 virus_growth_asymp = virus_growth_presymp = virus_growth_symp = 1e-3/day
@@ -65,7 +65,7 @@ disease_classes = (
   susceptible = ["Susceptible"],
   infectious = ["Asymptomatic", "Presymptomatic", "Symptomatic"]
 )
-abun_v = (Virus = 0,)
+abun_v = (Environment = 0, Force = 0)
 
 # Dispersal kernels for virus dispersal from different disease classes
 dispersal_dists = fill(1.0km, numclasses)
@@ -148,7 +148,7 @@ disease_classes = (
   susceptible = ["Susceptible"],
   infectious = ["Asymptomatic", "Presymptomatic", "Symptomatic"]
 )
-abun_v = (Virus = 0,)
+abun_v = (Environment = 0, Force = 0)
 
 # Dispersal kernels for virus dispersal from different disease classes
 dispersal_dists = fill(1.0km, numclasses)

--- a/test/canonical/test_SEIR.jl
+++ b/test/canonical/test_SEIR.jl
@@ -10,7 +10,7 @@ do_save = (@isdefined do_save) ? do_save : false
 save_path = (@isdefined save_path) ? save_path : pwd()
 
 numclasses = 5
-numvirus = 1
+numvirus = 2
 # Set simulation parameters
 birth = fill(0.0/day, numclasses)
 death = fill(0.0/day, numclasses)
@@ -42,7 +42,7 @@ disease_classes = (
     susceptible = ["Susceptible"],
     infectious = ["Infected"]
 )
-abun_v = (Virus = 0,)
+abun_v = (Environment = 0, Force = 0)
 
 # Dispersal kernels for virus and disease classes
 dispersal_dists = fill(100.0km, numclasses)

--- a/test/canonical/test_SEIRS.jl
+++ b/test/canonical/test_SEIRS.jl
@@ -9,7 +9,7 @@ do_save = (@isdefined do_save) ? do_save : false
 save_path = (@isdefined save_path) ? save_path : pwd()
 
 numclasses = 5
-numvirus = 1
+numvirus = 2
 # Set simulation parameters
 birth = fill(0.0/day, numclasses)
 death = fill(0.0/day, numclasses)
@@ -40,7 +40,7 @@ disease_classes = (
   susceptible = ["Susceptible"],
   infectious = ["Infected"]
 )
-abun_v = (Virus = 0,)
+abun_v = (Environment = 0, Force = 0)
 # Dispersal kernels for virus and disease classes
 dispersal_dists = fill(100.0km, numclasses)
 dispersal_dists[3] = 700.0km

--- a/test/canonical/test_SIR.jl
+++ b/test/canonical/test_SIR.jl
@@ -10,7 +10,7 @@ save_path = (@isdefined save_path) ? save_path : pwd()
 
 grid_sizes = [4, 8, 16]
 numclasses = 4
-numvirus = 1
+numvirus = 2
 abuns = Vector{Array{Int64, 3}}(undef, length(grid_sizes))
 sumabuns = Vector{Array{Int64, 2}}(undef, length(grid_sizes))
 for i in eachindex(grid_sizes)
@@ -41,7 +41,7 @@ for i in eachindex(grid_sizes)
         susceptible = ["Susceptible"],
         infectious = ["Infected"]
     )
-    abun_v = (Virus = 0,)
+    abun_v = (Environment = 0, Force = 0)
 
     # Dispersal kernels for virus and disease classes
     dispersal_dists = fill(100.0km, numclasses)

--- a/test/canonical/test_SIS.jl
+++ b/test/canonical/test_SIS.jl
@@ -10,7 +10,7 @@ save_path = (@isdefined save_path) ? save_path : pwd()
 
 grid_sizes = [4, 8, 16]
 numclasses = 3
-numvirus = 1
+numvirus = 2
 abuns = Vector{Array{Int64, 3}}(undef, length(grid_sizes))
 sumabuns = Vector{Array{Int64, 2}}(undef, length(grid_sizes))
 for i in eachindex(grid_sizes)
@@ -44,7 +44,7 @@ for i in eachindex(grid_sizes)
         susceptible = ["Susceptible"],
         infectious = ["Infected"]
     )
-    abun_v = (Virus = virus,)
+    abun_v = (Environment = virus, Force = 0)
 
     # Dispersal kernels for virus and disease classes
     dispersal_dists = fill(100.0km, numclasses)

--- a/test/canonical/test_age.jl
+++ b/test/canonical/test_age.jl
@@ -10,7 +10,7 @@ save_path = (@isdefined save_path) ? save_path : pwd()
 
 age_cats = [1, 2, 4]
 numclasses = 3
-numvirus = 1
+numvirus = 2
 abuns = Vector{Array{Int64, 3}}(undef, length(age_cats))
 sumabuns = Vector{Array{Int64, 2}}(undef, length(age_cats))
 for i in eachindex(age_cats)
@@ -36,7 +36,7 @@ for i in eachindex(age_cats)
     epienv = simplehabitatAE(298.0K, grid, area, NoControl())
 
     # Set initial population sizes for all categories: Virus, Susceptible, Infected, Recovered
-    virus = 0
+    virus_env = 0
     susceptible = fill(Int64.(50_000_000/age_cats[i]), age_cats[i])
     infected = fill(Int64.(10_000/age_cats[i]), age_cats[i])
     dead = fill(0, age_cats[i])
@@ -51,7 +51,7 @@ for i in eachindex(age_cats)
         susceptible = ["Susceptible"],
         infectious = ["Infected"]
     )
-    abun_v = (Virus = virus,)
+    abun_v = (Environment = virus_env, Force = 0)
 
     # Dispersal kernels for virus and disease classes
     dispersal_dists = fill(100.0km, numclasses * age_cats[i])


### PR DESCRIPTION
To close https://github.com/ScottishCovidResponse/SCRCIssueTracking/issues/311

Could you check whether this is all we need and whether there is any additional tests need to be added?

A couple of small questions
- I initiated the force of infection abun to be 0 in all examples/tests. Is that fair?
- This [line](https://github.com/ScottishCovidResponse/Simulation.jl/blob/dev/src/Epidemiology/EpiList.jl#L138-L139) means that if I call this category "Force", the name got recorded is "Force2". Is that ok? Why was the virus naming constructed in this way in the first place? Want to be able to know the index associated with each category?


- I'm still not super sure about the relationship between virus in `environment` and `force`. If I understand it correctly, at any time t, the virus in environment is `virus_already_in_env + virus_generated_by_people - virus_decay`. Now we record `virus_generated_by_people` at each time as `force_of_infection`. Later in the code, we have something like [thiks](https://github.com/ScottishCovidResponse/Simulation.jl/blob/dev/src/Epidemiology/EpiGenerate.jl#L121) that add up the contribution from both virus in the env and force. My question is, did we count `virus_generated_by_people` twice through both `env` abundance and `force` abundance?