### PR TITLE
WIP: Use AxisArray for abundances.grid

### DIFF
--- a/examples/Epidemiology/Scotland_run.jl
+++ b/examples/Epidemiology/Scotland_run.jl
@@ -52,6 +52,8 @@ initial_pop = cat(
     dims=ndims(scotpop)+1
 )
 initial_pop = AxisArray(initial_pop, compartment_axes);
+# To be able to easily reshape to match abundances.matrix, the spatial axes have to be at
+# the end
 initial_pop = permutedims(initial_pop, [3, 4, 1, 2])
 
 susc = @view initial_pop[class=:Susceptible]

--- a/src/Epidemiology/EpiEnv.jl
+++ b/src/Epidemiology/EpiEnv.jl
@@ -125,12 +125,12 @@ else one is created with all grid cells active.
 """
 function simplehabitatAE(
     val::Union{Float64, Unitful.Quantity{Float64}},
+    dimension::Tuple{Int64, Int64},
     area::Unitful.Area{Float64},
     active::AbstractMatrix{Bool},
     control::C,
-    initial_population::AbstractArray{<:Integer}, # =zeros(Int, dimension),
+    initial_population::AbstractArray{<:Integer}=zeros(Int, dimension),
 ) where C <: AbstractControl
-    dimension = size(active)
     if typeof(val) <: Unitful.Temperature
         val = uconvert(K, val)
     end
@@ -191,7 +191,6 @@ function simplehabitatAE(
     if all(inactive.(initial_population))
         throw(ArgumentError("initial_population is all NaN / missing / 0"))
     end
-    dimension = size(initial_population)
     active = Array{Bool}(.!inactive.(initial_population))
     initial_population = _convert_population(initial_population, active)
     # reduce to 2D matrix
@@ -199,7 +198,8 @@ function simplehabitatAE(
     reducedims = Tuple(1:ndims(active)-2)
     active = reduce(|, active, dims=reducedims)
     active = dropdims(active, dims=reducedims)
-    return simplehabitatAE(val, area, active, control, initial_population)
+    dimension = size(active)
+    return simplehabitatAE(val, dimension, area, active, control, initial_population)
 end
 
 """

--- a/src/Epidemiology/EpiHelper.jl
+++ b/src/Epidemiology/EpiHelper.jl
@@ -93,7 +93,7 @@ function simulate_record!(
 
   # - initialise and save the first timestep abuns/storage to HDF5
   # construct axes for abuns/storage matrix
-  grid_id = map(Iterators.product(axisvalues(epi.epienv.initial_population)...)) do (x,y)
+  grid_id = map(Iterators.product(axisvalues(epi.epienv.initial_population)[end-1:end]...)) do (x,y)
       return string.(x, "-", y)
   end
   # TODO: confirm converting `grid_id` from matrix to vector in the way below gives the

--- a/src/Epidemiology/EpiLandscape.jl
+++ b/src/Epidemiology/EpiLandscape.jl
@@ -7,13 +7,17 @@ Disease class abundances housed in the landscape. These are represented in both 
 mutable struct EpiLandscape
   matrix::Matrix{Int64}
   matrix_v::Matrix{Int64}
-  grid::Array{Int64, 3}
+  grid::AxisArray{Int64}
   seed::Vector{MersenneTwister}
-  function EpiLandscape(human_abun::Matrix{Int64}, virus_abun::Matrix{Int64}, d1::Tuple)
-    return new(human_abun, virus_abun, reshape(human_abun, d1), [MersenneTwister(rand(UInt)) for _ in 1:Threads.nthreads()])
+  function EpiLandscape(human_abun::Matrix{Int64}, virus_abun::Matrix{Int64}, ax)
+    d = length.(ax)
+    grid = AxisArray(reshape(human_abun, d), ax)
+    return new(human_abun, virus_abun, grid, [MersenneTwister(rand(UInt)) for _ in 1:Threads.nthreads()])
   end
-  function EpiLandscape(human_abun::Matrix{Int64}, virus_abun::Matrix{Int64}, d1::Tuple, d2::Tuple, seed::Vector{MersenneTwister})
-    return new(human_abun, virus_abun, reshape(human_abun, d1), seed)
+  function EpiLandscape(human_abun::Matrix{Int64}, virus_abun::Matrix{Int64}, ax, d2::Tuple, seed::Vector{MersenneTwister})
+    d = length.(ax)
+    grid = AxisArray(reshape(human_abun, d), ax)
+    return new(human_abun, virus_abun, grid, seed)
   end
 end
 
@@ -38,6 +42,6 @@ EpiList.
 function emptyepilandscape(epienv::GridEpiEnv, epilist::EpiList)
   mat_human = zeros(Int64, counttypes(epilist.human, true), countsubcommunities(epienv))
   mat_virus = zeros(Int64, counttypes(epilist.virus, true), countsubcommunities(epienv))
-  dimension = (counttypes(epilist.human, true), _getdimension(epienv.habitat)...)
-  return EpiLandscape(mat_human, mat_virus, dimension)
+  ax = AxisArrays.axes(epienv.initial_population)
+  return EpiLandscape(mat_human, mat_virus, ax)
 end

--- a/src/Epidemiology/EpiSystem.jl
+++ b/src/Epidemiology/EpiSystem.jl
@@ -68,12 +68,7 @@ end
 function EpiSystem(epilist::EpiList, epienv::GridEpiEnv, rel::AbstractTraitRelationship)
     epi = EpiSystem(populate!, epilist, epienv, rel)
     # Add in the initial susceptible population
-    idx = findfirst(epilist.human.names .== "Susceptible")
-    if idx == nothing
-        msg = "epilist has no Susceptible category. epilist.names = $(epilist.human.names)"
-        throw(ArgumentError(msg))
-    end
-    epi.abundances.grid[idx, :, :] .+= epienv.initial_population
+    epi.abundances.grid .+= epienv.initial_population
     return epi
 end
 


### PR DESCRIPTION
Possible solution to https://github.com/ScottishCovidResponse/SCRCIssueTracking/issues/281

This makes `EpiLandscape.grid` a multi-D `AxisArray` view onto `EpiLandscape.matrix`.

Example usage is in `Scotland_run.jl`. It sets up an `initial_population`  which is an `AxisArray` of the appropriate dimension and axes. All the initial setting of infected individuals etc is done on that array, which is then used to populate the initial `matrix / grid`.

Advantages:
- Directly use the `AxisArray` data coming from `parse_hdf5` (e.g. don't have to re-write all the age categories) 
- Greatly simplifies interaction with the abundances matrix, makes it more extensible and less error prone. E.g. setting the initial exposed individuals is changed from
```julia
age_and_cells = Iterators.product(1:age_categories,
                                  1:size(epi.abundances.matrix, 2))
# Take all susceptibles of each age per cell
pop_weights = epi.abundances.matrix[vcat(cat_idx[:, 1]...), :]
# It would be nice if it wasn't necessary to call collect here
N_cells = size(epi.abundances.matrix, 2)
samp = sample(collect(age_and_cells), weights(1.0 .* vec(pop_weights)), 100)
age_ids = getfield.(samp, 1)
cell_ids = getfield.(samp, 2)

for i in eachindex(age_ids)
    if (epi.abundances.matrix[cat_idx[age_ids[i], 1], cell_ids[i]] > 0)
        # Add to exposed
        epi.abundances.matrix[cat_idx[age_ids[i], 2], cell_ids[i]] += 1
        # Remove from susceptible
        epi.abundances.matrix[cat_idx[age_ids[i], 1], cell_ids[i]] -= 1
    end
end
```
to the following (could be even shorter if various AxisArray issues were fixed)
```julia
susc = @view initial_pop[class=:Susceptible]
exposed = @view initial_pop[class=:Exposed]
# Weight samples by number of susceptibles
samples = sample(CartesianIndices(susc), weights(1.0 .* vec(susc)), 100)
for samp in samples
    susc[samp] > 0 || continue
    # Add to exposed
    exposed[samp] += 1
    # Remove from susceptible
    susc[samp] -= 1
end
```
- Makes plotting nicer, since we can "know" about the dimensions to sum over

Disadvantages:
- `AxisArrays` is a bit flaky, it has a bunch of [issues](https://github.com/JuliaArrays/AxisArrays.jl/issues). So far I didn't find anything insurmountable...
- Seems to allocate more, I'm not sure why (might be able to improve this). On the Scotland example, `@btime simulate_record!`:
```
dev:
  5.525 s (3881312 allocations: 205.22 MiB)

this PR:
  5.946 s (7612784 allocations: 428.20 MiB)
```
- Only addresses `abundances`, doesn't address other things like the transition matrix, etc