### PR TITLE
Remove limits to OnlineStatsBase

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -55,8 +55,6 @@ ArchGDAL = "~0.4.0"
 DataAPI = "=1.2.0"
 HDF5 = "0.13.2"
 JLSO = "2.3"
-OnlineStats = "=1.2.0"
-OnlineStatsBase = "=1.2.8"
 Phylo = "^0.4.2"
 julia = "1.1"
 


### PR DESCRIPTION
Blocking me from using the package with others like JuliaDBMeta  (which I use for the UK climate modelling package). Seems to pass tests now without these constraints anyway.